### PR TITLE
Restrict StreamIO sample to Windows & Linux

### DIFF
--- a/Other/README.md
+++ b/Other/README.md
@@ -2,4 +2,4 @@
 This sample illustrates how to utilize memory only for processing temporary files rather than writing to disk.
 
 ## ***StreamIO***
-Reads a PDF document from a stream and writes one to a stream.
+Reads a PDF document from a stream and writes one to a stream. (Available for Windows and Linux only.)

--- a/Other/StreamIO/pom.xml
+++ b/Other/StreamIO/pom.xml
@@ -22,18 +22,6 @@
       </properties>
     </profile>
     <profile>
-      <id>MacArm</id>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-      <properties>
-        <jni.classifier>mac-arm-64-jni</jni.classifier>
-      </properties>
-    </profile>
-    <profile>
       <id>Linux64</id>
       <activation>
         <os>


### PR DESCRIPTION
There is currently a problem with the StreamIO sample on Mac Arm, disable it until we have solved the problem.