### PR TITLE
Tidy up samples.

### DIFF
--- a/Annotations/Annotations/src/main/java/com/datalogics/pdfl/samples/Annotations.java
+++ b/Annotations/Annotations/src/main/java/com/datalogics/pdfl/samples/Annotations.java
@@ -11,13 +11,7 @@ import com.datalogics.PDFL.Page;
  * 
  * This sample demonstrates how to find and describe annotations in an existing PDF document.
  * 
- * For more detail see the description of the Annotations sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-annotations-in-pdf-files#annotations
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class Annotations {

--- a/Annotations/InkAnnotations/src/main/java/com/datalogics/pdfl/samples/InkAnnotations.java
+++ b/Annotations/InkAnnotations/src/main/java/com/datalogics/pdfl/samples/InkAnnotations.java
@@ -13,13 +13,7 @@ import java.util.List;
  * This sample creates and adds a new Ink annotation to a PDF document. An Ink annotation is a freeform line,
  * similar to what you would create with a pen, or with a stylus on a mobile device.
  *
- * For more detail see the description of the InkAnnotations sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-annotations-in-pdf-files#inkannotations
- *  
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/LinkAnnotations/src/main/java/com/datalogics/pdfl/samples/LinkAnnotations.java
+++ b/Annotations/LinkAnnotations/src/main/java/com/datalogics/pdfl/samples/LinkAnnotations.java
@@ -15,13 +15,8 @@ import com.datalogics.PDFL.ViewDestination;
  * 
  * This program creates a PDF file with an embedded hyperlink, which takes the reader to the second page of the document.
  * 
- * For more detail see the description of the LinkAnnotation sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-annotations-in-pdf-files#linkannotation
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  */
 public class LinkAnnotations {
 

--- a/Annotations/PolyLineAnnotations/src/main/java/com/datalogics/pdfl/samples/PolyLineAnnotations.java
+++ b/Annotations/PolyLineAnnotations/src/main/java/com/datalogics/pdfl/samples/PolyLineAnnotations.java
@@ -11,10 +11,7 @@ import com.datalogics.PDFL.*;
  * This program generates a PDF output file with a line shape (an angle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/PolygonAnnotations/src/main/java/com/datalogics/pdfl/samples/PolygonAnnotations.java
+++ b/Annotations/PolygonAnnotations/src/main/java/com/datalogics/pdfl/samples/PolygonAnnotations.java
@@ -11,10 +11,7 @@ import com.datalogics.PDFL.*;
  * This program generates a PDF output file with a polygon shape (a triangle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AECancelProc.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AECancelProc.java
@@ -1,12 +1,9 @@
 /*
  *
- * A sample which demonstrates the use of the DLE API to create a new
+ * A sample which demonstrates how to create a new
  * PDF file and add two pages containing a series of Path and Text elements
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEProgressMonitor.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEProgressMonitor.java
@@ -1,12 +1,9 @@
 /*
  *
- * A sample which demonstrates the use of the DLE API to create a new
+ * A sample which demonstrates how to create a new
  * PDF file and add two pages containing a series of Path and Text elements
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEReportProc.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEReportProc.java
@@ -1,13 +1,10 @@
 
 /*
  *
- * A sample which demonstrates the use of the DLE API to create a new
+ * A sample which demonstrates how to create a new
  * PDF file and add two pages containing a series of Path and Text elements
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AddElements.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AddElements.java
@@ -7,10 +7,7 @@ package com.datalogics.pdfl.samples;
  * The third page features a rectangle and a curved design. Use this sample for ideas on how
  * to draw an image on a PDF page.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.*;

--- a/ContentCreation/AddHeaderFooter/src/main/java/com/datalogics/pdfl/samples/AddHeaderFooter.java
+++ b/ContentCreation/AddHeaderFooter/src/main/java/com/datalogics/pdfl/samples/AddHeaderFooter.java
@@ -6,9 +6,6 @@ package com.datalogics.pdfl.samples;
  * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 import com.datalogics.PDFL.Document;
 import com.datalogics.PDFL.Font;

--- a/ContentCreation/Clips/src/main/java/com/datalogics/pdfl/samples/Clips.java
+++ b/ContentCreation/Clips/src/main/java/com/datalogics/pdfl/samples/Clips.java
@@ -18,13 +18,7 @@ import com.datalogics.PDFL.*;
 /*
  * This sample demonstrates working with Clip objects. A clipping path is used to edit the borders of a graphics object.
  * 
- * For more detail see the description of the Clips sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/manipulating-graphics-and-separating-colors-for-images
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/CreateBookmarks/src/main/java/com/datalogics/pdfl/samples/CreateBookmarks.java
+++ b/ContentCreation/CreateBookmarks/src/main/java/com/datalogics/pdfl/samples/CreateBookmarks.java
@@ -20,15 +20,12 @@ import com.datalogics.PDFL.*;
  * assigned to each section heading. The user could click on a heading link in the Table of Contents 
  * and move directly to the appropriate section of the document.
  * 
- * Open the CreateBookmarks-out.PDF file in Acrobat and click the Bookmark icon to display the bookmarks that
+ * Open the CreateBookmarks-out.PDF file in a PDF Viewer and display the bookmarks that
  * the CreateBookmarks program added to the output PDF document. Several of these bookmarks will zoom to
  * parts of the page. The last three, Child1, 2, and 3, are dummy bookmarks that do not respond when you
  * click on them.  They demonstrate how to rearrange existing bookmarks.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class CreateBookmarks 

--- a/ContentCreation/GradientShade/src/main/java/com/datalogics/pdfl/samples/GradientShade.java
+++ b/ContentCreation/GradientShade/src/main/java/com/datalogics/pdfl/samples/GradientShade.java
@@ -10,13 +10,7 @@ import com.datalogics.PDFL.*;
  * This sample demonstrates changing the shading of an image on a PDF document page. The image gradually
  * changes from black on the left side of the image, to red on the right side.
  * 
- * For more detail see the description of the GradientShade sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class GradientShade {

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalGrayColorSpace.java
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalGrayColorSpace.java
@@ -2,13 +2,7 @@
  * 
  * Demonstrates working with the Calibrated Gray Space (CaLGray), based on the CIE color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalRGBColorSpace.java
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalRGBColorSpace.java
@@ -3,13 +3,7 @@
  * Demonstrates working with the Calibrated RGB Color Space, based on the CIE color space.
  * A, B, and C represent red, blue, and green color values.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithDeviceNColorSpace.java
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithDeviceNColorSpace.java
@@ -8,14 +8,8 @@ import java.util.List;
 /*
  * This sample demonstrates creating a file containing a DeviceN color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
+*
  */
 public class MakeDocWithDeviceNColorSpace {
 

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithICCBasedColorSpace.java
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithICCBasedColorSpace.java
@@ -9,13 +9,7 @@ import java.util.EnumSet;
 /*
  * This sample demonstrates creating a file containing an ICC-based color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 public class MakeDocWithICCBasedColorSpace {

--- a/ContentCreation/MakeDocWithIndexedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithIndexedColorSpace.java
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithIndexedColorSpace.java
@@ -26,13 +26,7 @@ import com.datalogics.PDFL.TextState;
  * to reduce the amount of system memory used for processing images when a limited
  * number of colors are needed.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithIndexedColorSpace {

--- a/ContentCreation/MakeDocWithLabColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithLabColorSpace.java
+++ b/ContentCreation/MakeDocWithLabColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithLabColorSpace.java
@@ -25,13 +25,7 @@ import java.util.List;
  * CIE XYZ color space, but it includes a dimension L, for lightness,
  * along with a and b coordinates, to define the color.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithLabColorSpace {

--- a/ContentCreation/MakeDocWithSeparationColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithSeparationColorSpace.java
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithSeparationColorSpace.java
@@ -8,13 +8,7 @@ import java.util.List;
 /*
 * This sample demonstrates creating a PDF document that uses a Separation color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2008-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithSeparationColorSpace {

--- a/ContentCreation/NameTrees/src/main/java/com/datalogics/pdfl/samples/NameTrees.java
+++ b/ContentCreation/NameTrees/src/main/java/com/datalogics/pdfl/samples/NameTrees.java
@@ -20,13 +20,7 @@ import com.datalogics.PDFL.*;
  * dictionary, instead of using a code value as a key to identify an object, a name tree
  * uses names as keys to map to data objects. 
  *
- * For more detail see the description of the NameTrees sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-large-amounts-of-data-in-a-pdf
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/NumberTrees/src/main/java/com/datalogics/pdfl/samples/NumberTrees.java
+++ b/ContentCreation/NumberTrees/src/main/java/com/datalogics/pdfl/samples/NumberTrees.java
@@ -9,13 +9,7 @@ import com.datalogics.PDFL.*;
  * keys used in a number tree are integers, rather than character strings, and these keys are sorted
  * in ascending numerical order. 
  *
- * For more detail see the description of the NumberTrees sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-large-amounts-of-data-in-a-pdf
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/RemoteGoToActions/src/main/java/com/datalogics/pdfl/samples/RemoteGoToActions.java
+++ b/ContentCreation/RemoteGoToActions/src/main/java/com/datalogics/pdfl/samples/RemoteGoToActions.java
@@ -21,13 +21,7 @@ import com.datalogics.PDFL.RemoteGoToAction;
  * RemoteGoToActions differs from LaunchActions in that it includes a RemoteDestination object.
  * This object describes the rectangle used in the PDF file in a series of statements at the command prompt. 
  *
- * For more detail see the description of the RemoteGoToActions sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-actions-in-pdf-files#remotegotoactions
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/WriteNChannelTiff/src/main/java/com/datalogics/pdfl/samples/WriteNChannelTiff.java
+++ b/ContentCreation/WriteNChannelTiff/src/main/java/com/datalogics/pdfl/samples/WriteNChannelTiff.java
@@ -16,13 +16,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
  * This sample generates a multi-page TIFF file, selecting graphics drawn from
  * the first page of the PDF document provided.
  * 
- * For more detail see the description of the WriteNChannelTiff sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/manipulating-graphics-and-separating-colors-for-images#writenchanneltiff
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/Actions/src/main/java/com/datalogics/pdfl/samples/Actions.java
+++ b/ContentModification/Actions/src/main/java/com/datalogics/pdfl/samples/Actions.java
@@ -18,10 +18,7 @@ import com.datalogics.PDFL.ViewDestination;
  * An action is added to the rectangle in the form of a hyperlink; if the reader
  * clicks on the rectangle, the system opens the Datalogics web page.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/AddCollection/src/main/java/com/datalogics/pdfl/samples/AddCollection.java
+++ b/ContentModification/AddCollection/src/main/java/com/datalogics/pdfl/samples/AddCollection.java
@@ -28,13 +28,7 @@ import com.datalogics.PDFL.Collection;
  * 
  * A PDF Portfolio can hold and display multiple additional files as attachments.
  * 
- * For more detail see the description of the AddCollection sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-a-pdf-collection-or-portfolio
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/ChangeLayerConfiguration/src/main/java/com/datalogics/pdfl/samples/ChangeLayerConfiguration.java
+++ b/ContentModification/ChangeLayerConfiguration/src/main/java/com/datalogics/pdfl/samples/ChangeLayerConfiguration.java
@@ -2,18 +2,12 @@
  * This sample changes the On/Off configuration for a set of Optional Content Groups,
  * or layers, within a PDF document. By changing the On or Off state in the default
  * configuration, the sample makes the layers visible or invisible when opened in a 
- * viewer like Adobe Acrobat.
+ * PDF viewer.
  * 
  * The sample changes the states of the layers in the document called Layers.pdf and
  * saves the result to a new PDF document.
- * 
- * For more detail see the description of the ChangeLayerConfiguration sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/layers-and-transparencies/ 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentModification/ChangeLinkColors/src/main/java/com/datalogics/pdfl/samples/ChangeLinkColors.java
+++ b/ContentModification/ChangeLinkColors/src/main/java/com/datalogics/pdfl/samples/ChangeLinkColors.java
@@ -13,13 +13,7 @@ import com.datalogics.PDFL.*;
  * rectangles, and then finds the text that lines up within these rectangles and changes the
  * color of each character that is a part of the hyperlink.  
  * 
- * For more detail see the description of the ChangeLinkColors sample program on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/working-with-annotations#changelinkcolors
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class ChangeLinkColors {

--- a/ContentModification/CreateLayer/src/main/java/com/datalogics/pdfl/samples/CreateLayer.java
+++ b/ContentModification/CreateLayer/src/main/java/com/datalogics/pdfl/samples/CreateLayer.java
@@ -5,14 +5,11 @@
  * The related ChangeLayerConfiguration program makes layers visible or invisible.
  * 
  * You can toggle back and forth to make the layer (the duck image) visible or invisible
- * in the PDF file. Open the output PDF document in Adobe Acrobat, click View and select
- * Show/Hide. Select Navigation Panes and Layers to display the layers in the PDF file. 
+ * in the PDF file. Open the output PDF document in a PDF Viewer, and you can view and hide
+ * the Layers. Select Navigation Panes and Layers to display the layers in the PDF file. 
  * Click on the box next to the name of the layer.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/ExtendedGraphicStates/src/main/java/com/datalogics/pdfl/samples/ExtendedGraphicStates.java
+++ b/ContentModification/ExtendedGraphicStates/src/main/java/com/datalogics/pdfl/samples/ExtendedGraphicStates.java
@@ -9,13 +9,7 @@ package com.datalogics.pdfl.samples;
  * 
  * This sample program shows how to use the Extended Graphic State object to add graphics parameters to an image.
  * 
- * For more detail see the description of the ExtendedGraphicState sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/adding-text-and-graphic-elements#extendedgraphicstates
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.BlendMode;

--- a/ContentModification/FlattenTransparency/src/main/java/com/datalogics/pdfl/samples/FlattenTransparency.java
+++ b/ContentModification/FlattenTransparency/src/main/java/com/datalogics/pdfl/samples/FlattenTransparency.java
@@ -18,13 +18,7 @@ import com.datalogics.PDFL.FlattenTransparencyParams;
  * appears on the page. The process to flatten a set of transparencies merges them
  * into a single image on the page.
  *
- * For more detail see the description of the FlattenTransparency sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/layers-and-transparencies/#flattentransparency 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -64,7 +58,7 @@ public class FlattenTransparency {
             if(isTransparent)
             {
                 // Flattening the document will check each page for transparency.
-                // If a page has transparency, DLE will create a new, flattened
+                // If a page has transparency, it will create a new, flattened
                 // version of the page and replace the original page with the
                 // new one.  Because of this, make sure to dispose of outstanding Page objects
                 // that refer to pages in the Document before calling flattenTransparency.

--- a/ContentModification/LaunchActions/src/main/java/com/datalogics/pdfl/samples/LaunchActions.java
+++ b/ContentModification/LaunchActions/src/main/java/com/datalogics/pdfl/samples/LaunchActions.java
@@ -17,10 +17,7 @@ import com.datalogics.PDFL.LaunchAction;
  * An action is added to the rectangle in the form of a hyperlink; if the reader clicks
  * on the rectangle, a different PDF file opens, showing an image.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/MergePDF/src/main/java/com/datalogics/pdfl/samples/MergePDF.java
+++ b/ContentModification/MergePDF/src/main/java/com/datalogics/pdfl/samples/MergePDF.java
@@ -15,9 +15,6 @@ import com.datalogics.PDFL.*;
  *
  * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 public class MergePDF {
     public static void main (String[] args) throws Throwable

--- a/ContentModification/PDFObject/src/main/java/com/datalogics/pdfl/samples/PDFObjectSample.java
+++ b/ContentModification/PDFObject/src/main/java/com/datalogics/pdfl/samples/PDFObjectSample.java
@@ -15,14 +15,8 @@ import com.datalogics.PDFL.Page;
 /*
  * This sample demonstrates working with data objects in a PDF document. It examines the Objects and displays
  * information about them.  The sample extracts the dictionary for an object called URIAction and updates it using PDFObjects.
- * 
- * For more detail see the description of the PDFObject sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pdfobject
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class PDFObjectSample {

--- a/ContentModification/PageLabels/src/main/java/com/datalogics/pdfl/samples/PageLabels.java
+++ b/ContentModification/PageLabels/src/main/java/com/datalogics/pdfl/samples/PageLabels.java
@@ -11,13 +11,7 @@ import com.datalogics.PDFL.NumberStyle;
  * This sample demonstrates working with page labels in a PDF document. Each PDF file has a 
  * data structure that governs how page numbers appear, such as the font and type of numeral.
  *
- * For more detail see the description of the PageLabels sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pagelabels
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/UnderlinesAndHighlights/src/main/java/com/datalogics/pdfl/samples/UnderlinesAndHighlights.java
+++ b/ContentModification/UnderlinesAndHighlights/src/main/java/com/datalogics/pdfl/samples/UnderlinesAndHighlights.java
@@ -26,10 +26,7 @@ import com.datalogics.PDFL.WordFinderVersion;
  * a National Weather Service web page, highlighting the word "Cloudy" wherever it appears and underlining
  * the word "Rain."
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class UnderlinesAndHighlights {

--- a/ContentModification/Watermark/src/main/java/com/datalogics/pdfl/samples/Watermark.java
+++ b/ContentModification/Watermark/src/main/java/com/datalogics/pdfl/samples/Watermark.java
@@ -14,13 +14,7 @@ import com.datalogics.PDFL.*;
  * a set of photographs shown in a PDF file so that they cannot be easily duplicated without
  * the permission of the owner.
  * 
- * For more detail see the description of the Watermark sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/adding-text-and-graphic-elements#watermark
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/DisplayPDF.java
+++ b/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/DisplayPDF.java
@@ -4,11 +4,8 @@ package com.datalogics.pdfl.samples;
  * This sample shows how to open a PDF document, search for text in the pages and highlight
  * the text. This utility is a simpler version of the JavaViewer sample.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- * 
  */
 
 import java.awt.Dimension;

--- a/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerFrame.java
+++ b/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerFrame.java
@@ -1,12 +1,9 @@
 /*
  * ViewerFrame.java
  *
- * Created on December 3, 2007, 2:26 PM
  *
- * Copyright (c) 2017, Datalogics, Inc. All rights reserved. 
+ * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved. 
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  */
 
 package com.datalogics.pdfl.samples;

--- a/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerSample.java
+++ b/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerSample.java
@@ -2,14 +2,10 @@ package com.datalogics.pdfl.samples;
 
 /*
  * 
- * A sample which demonstrates the use of the DLE API to view a PDF
- * file and search for text in the file and highlight them using the
- * C# drawing library.
+ * A sample which demonstrates the use of the API to view a PDF
+ * file and search for text in the file and highlight them.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import javax.swing.*;

--- a/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplay.java
+++ b/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplay.java
@@ -6,10 +6,7 @@ package com.datalogics.pdfl.samples;
  * in a special window on your computer. The program defines an optional input document to display.
  * The entire first page is converted to a graphic.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayFrame.java
+++ b/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayFrame.java
@@ -1,10 +1,8 @@
 /*
  * ImageDisplayFrame.java
  *
- * Copyright (c) 2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  */
 
 package com.datalogics.pdfl.samples;

--- a/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayer.java
+++ b/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayer.java
@@ -1,10 +1,8 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2017, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved. 
 
-For complete copyright information, refer to:
-http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  */
 
 import java.awt.Dimension;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/ActionProperties.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/ActionProperties.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationConsts.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationConsts.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationFactory.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationFactory.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListener.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListenerBroadcaster.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListenerBroadcaster.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationProperties.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationProperties.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/BaseAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/BaseAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/FreeTextAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/FreeTextAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/GroupAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/GroupAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/InkAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/InkAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LineAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LineAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LinkAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LinkAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolyAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolyAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolygonAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolygonAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolylineAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolylineAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/RectangularAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/RectangularAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/TextMarkupAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/TextMarkupAnnotationHolder.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Annotations;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AppendCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AppendCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AutosizeVerticallyCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AutosizeVerticallyCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseAnnotationCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseGroupCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseGroupCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeAnnotationColorCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeAnnotationColorCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeArrowHeadCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeArrowHeadCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeDashPatternCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeDashPatternCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontAlignmentCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontAlignmentCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontFaceCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontFaceCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontSizeCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontSizeCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeLineWidthCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeLineWidthCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CloseCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CloseCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandStack.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandStack.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandType.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandType.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CreateAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CreateAnnotationCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CustomEditCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CustomEditCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteAnnotationCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteGroupCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteGroupCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DocumentCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DocumentCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditAnnotationCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditGroupCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditGroupCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/GoToCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/GoToCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/LayersCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/LayersCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/MarqueeZoomCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/MarqueeZoomCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/NavigateCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/NavigateCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/OpenCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/OpenCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PendingCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PendingCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PrintCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PrintCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/SaveCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/SaveCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ScrollCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ScrollCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ShowBorderCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ShowBorderCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UnlockCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UnlockCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UpdatePropertyCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UpdatePropertyCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewModeCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewModeCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ZoomCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ZoomCommand.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document.Command;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Constants.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Constants.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/DocumentListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/DocumentListener.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/JavaDocument.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/JavaDocument.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Document;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/DropDownButtonModel.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/DropDownButtonModel.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/JavaViewer.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/JavaViewer.java
@@ -1,13 +1,7 @@
 /*
  * This sample is a utility that demonstrates a PDF viewing tool. You can use it to open, display, and edit PDF files.
  * 
- * For more detail see the description of the JavaViewer on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/viewing-pdf-files
- * 
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/MenuButton.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/MenuButton.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Application.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Application.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/ApplicationController.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/ApplicationController.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/BookmarksPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/BookmarksPresenter.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/DocumentCache.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/DocumentCache.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Cache;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageCache.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageCache.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Cache;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageModel.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageModel.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Cache;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ApplicationMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ApplicationMode.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Enums;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/DialogMenuItem.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/DialogMenuItem.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Enums;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/MenuType.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/MenuType.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Enums;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/NavigateMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/NavigateMode.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Enums;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/PageViewMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/PageViewMode.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Enums;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ZoomMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ZoomMode.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Enums;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/BaseInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/BaseInteractive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditAnnotationInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditAnnotationInteractive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorListener.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorStates.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorStates.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/AnnotationEditorFactory.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/AnnotationEditorFactory.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationOutput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CircleAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CircleAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateCustomEditAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateCustomEditAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateInkAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateInkAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateLineAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateLineAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreatePolyAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreatePolyAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateRectangularAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateRectangularAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupOutput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationOuptut.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationOuptut.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/FreeTextAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/FreeTextAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationOutput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GuideRectangle.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GuideRectangle.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/Hit.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/Hit.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationOutput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/InkAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/InkAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LineAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LineAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetOutput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyLineAnnoationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyLineAnnoationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolygonAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolygonAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectAnnotationInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectGroupInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectGroupInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SquareAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SquareAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextEditInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextEditInput.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextMarkupAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextMarkupAnnotationEditor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive.Editors;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Interactive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Interactive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/LinkTargetInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/LinkTargetInteractive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/MarqueeZoomInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/MarqueeZoomInteractive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ScrollModeInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ScrollModeInteractive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ZoomModeInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ZoomModeInteractive.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation.Interactive;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/KeyNavigationPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/KeyNavigationPresenter.java
@@ -1,9 +1,5 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/LayersPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/LayersPresenter.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/PDFPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/PDFPresenter.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/TextSearchPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/TextSearchPresenter.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Utils.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Utils.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AnnotationPropertyAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AnnotationPropertyAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AppendAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AppendAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ApplicationModeAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ApplicationModeAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AutosizeVerticallyAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AutosizeVerticallyAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AvailableActions.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AvailableActions.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeAnnotationColor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeAnnotationColor.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeArrowHead.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeArrowHead.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeDashPatternAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeDashPatternAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeLineWidthAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeLineWidthAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CloseAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CloseAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CreateAnnotationAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CreateAnnotationAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DeleteAnnotationAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DeleteAnnotationAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DialogMenuAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DialogMenuAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontAlignmentChangedAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontAlignmentChangedAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontFaceChangedAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontFaceChangedAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontSizeChangedAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontSizeChangedAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/MonitorResolutionAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/MonitorResolutionAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/NavigateAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/NavigateAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/OpenAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/OpenAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/PrintAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/PrintAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/RedoAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/RedoAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SaveAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SaveAction.java
@@ -1,8 +1,5 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ShowBorderAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ShowBorderAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SimpleAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SimpleAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/TextSearchAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/TextSearchAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UndoAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UndoAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UnlockAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UnlockAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ViewModeAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ViewModeAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ZoomAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ZoomAction.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Actions;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/BookmarksView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/BookmarksView.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ColorPickerIcon.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ColorPickerIcon.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/DialogsView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/DialogsView.java
@@ -1,8 +1,5 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/InputDataView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/InputDataView.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Bookmarks.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Bookmarks.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/ColorPicker.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/ColorPicker.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/DialogMenuResultNotifier.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/DialogMenuResultNotifier.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Dialogs.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Dialogs.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/InputData.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/InputData.java
@@ -1,8 +1,5 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Layers.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Layers.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/LinkTargetDialog.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/LinkTargetDialog.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PDF.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PDF.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PropertyDialog.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PropertyDialog.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/TextEdit.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/TextEdit.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Viewer.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Viewer.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views.Interfaces;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/JavaViewerComponent.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/JavaViewerComponent.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/LayersView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/LayersView.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/MessageDialogType.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/MessageDialogType.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/PDFView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/PDFView.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ScrollingView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ScrollingView.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/SelectionListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/SelectionListener.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/TextEditView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/TextEditView.java
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2011-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
  * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 package com.datalogics.pdfl.JavaViewer.Views;

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/EnumObjectsForTree.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/EnumObjectsForTree.java
@@ -1,9 +1,6 @@
 /*
  * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  *
  * ========================== Enum Objects For Tree ===========================
  * This file contains two classes.  Both operate the same way but handle two

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilenameFilter.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilenameFilter.java
@@ -1,8 +1,6 @@
 /*
- * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  * ============================ PDFFilenameFilter ===================================
  * This filter is used with the file dialog to limit displayed files to those

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilter.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilter.java
@@ -1,8 +1,5 @@
 /*
- * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
  *
  * ============================ PDFFilter ===================================
  * This filter is used with the file chooser to limit displayed files to those

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFNode.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFNode.java
@@ -1,8 +1,5 @@
 /*
- * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
  *
  *
  * =============================== PDF NODE ===================================

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectExplorer.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectExplorer.java
@@ -4,13 +4,7 @@
  * information about objects embedded in a PDF file. These objects include arrays, dictionaries,
  * streams of characters, and integers.
  *
- * For more detail see the description of the PDFObjectExplorer sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pdfobjectexplorer
- * 
- * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;
@@ -34,7 +28,7 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 
-// Import classes from DLE
+// Import classes
 import com.datalogics.PDFL.Library;
 import com.datalogics.PDFL.Document;
 import com.datalogics.PDFL.PDFObject;

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectTreeIconRenderer.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectTreeIconRenderer.java
@@ -1,8 +1,5 @@
 /*
- * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
  *
  *
  * ===================== PDF Object Tree Icon Renderer ========================
@@ -17,7 +14,7 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.ImageIcon;
 import javax.swing.JTree;
 
-// Import classes from DLE
+// Import classes
 import com.datalogics.PDFL.PDFObject;
 import com.datalogics.PDFL.PDFArray;
 import com.datalogics.PDFL.PDFBoolean;

--- a/DocumentConversion/ColorConvertDocument/src/main/java/com/datalogics/pdfl/samples/ColorConvertDocument.java
+++ b/DocumentConversion/ColorConvertDocument/src/main/java/com/datalogics/pdfl/samples/ColorConvertDocument.java
@@ -26,13 +26,7 @@ import com.datalogics.PDFL.ColorConvertParams;
  * Note that the color profile is not embedded by default; rather, the default is not to embed the color profile.
  * The user must set the option to embed to True.
  * 
- * For more detail see the description of the ColorConvertDocument sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/color-conversion
- * 
- * Copyright (c) 2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
  *
  */
  

--- a/DocumentConversion/ConvertToOffice/src/main/java/com/datalogics/pdfl/samples/ConvertToOffice.java
+++ b/DocumentConversion/ConvertToOffice/src/main/java/com/datalogics/pdfl/samples/ConvertToOffice.java
@@ -9,13 +9,7 @@ import com.datalogics.PDFL.Library;
  *
  * ConvertToOffice converts sample PDF documents to Office Documents.
  *
- * For more detail see the description of the ConvertToOffice sample program on our Developer’s site,
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/converting-and-merging-pdf-content/
- *
  * Copyright (c) 2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 public class ConvertToOffice

--- a/DocumentConversion/CreateDocFromXPS/src/main/java/com/datalogics/pdfl/samples/CreateDocFromXPS.java
+++ b/DocumentConversion/CreateDocFromXPS/src/main/java/com/datalogics/pdfl/samples/CreateDocFromXPS.java
@@ -13,12 +13,7 @@ import com.datalogics.PDFL.XPSConvertParams;
  * XML Paper Specification (XPS) is a standard document format that Microsoft created in 2006
  * as an alternative to the PDF format.  
  *
- * Copyright (c) 2007-2010, Datalogics, Inc. All rights reserved.
- *
- * The information and code in this sample is for the exclusive use of Datalogics
- * customers and evaluation users only.  Datalogics permits you to use, modify and
- * distribute this file in accordance with the terms of your license agreement.
- * Sample code is for demonstrative purposes only and is not intended for production use.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -37,9 +32,9 @@ public class CreateDocFromXPS {
             // for creating the document.
             XPSConvertParams xpsparams = new XPSConvertParams();
             
-            // DLE requires a .joboptions file to specify settings for XPS conversion. 
+            // Use a .joboptions file to specify settings for XPS conversion.
             // A default .joboptions file is provided in the Resources directory of 
-            // the DLE distribution.  This file is used by default, but a custom file
+            // the distribution.  This file is used by default, but a custom file
             // can be used instead by setting the pathToSettingsFile property.
             System.out.println("Using settings file located at: " + xpsparams.getPathToSettingsFile());
             

--- a/DocumentConversion/FacturXConverter/src/main/java/com/datalogics/pdfl/samples/FacturXConverter.java
+++ b/DocumentConversion/FacturXConverter/src/main/java/com/datalogics/pdfl/samples/FacturXConverter.java
@@ -19,13 +19,7 @@ import com.datalogics.PDFL.PDFName;
  *
  * This sample demonstrates converting the input PDF with the input Invoice XML to a Factur-X compliant PDF.
  *
- * For more detail see the description of the FacturXConverter sample program on our Developer’s site,
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/converting-and-merging-pdf-content/#facturxconverter
- *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 public class FacturXConverter

--- a/DocumentConversion/PDFAConverter/src/main/java/com/datalogics/pdfl/samples/PDFAConverter.java
+++ b/DocumentConversion/PDFAConverter/src/main/java/com/datalogics/pdfl/samples/PDFAConverter.java
@@ -16,13 +16,7 @@ import com.datalogics.PDFL.PDFAConvertResult;
  * This sample demonstrates converting a standard PDF document into a
  * PDF Archive, or PDF/A, compliant version of a PDF file.
  *
- * For more detail see the description of the PDFAConverter sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/converting-and-merging-pdf-content
- * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 public class PDFAConverter

--- a/DocumentConversion/PDFXConverter/src/main/java/com/datalogics/pdfl/samples/PDFXConverter.java
+++ b/DocumentConversion/PDFXConverter/src/main/java/com/datalogics/pdfl/samples/PDFXConverter.java
@@ -15,13 +15,7 @@ import com.datalogics.PDFL.PDFXConvertResult;
  * 
  * The sample takes a default input and output a document (both optional). 
  * 
- * For more detail see the description of the PDFXConverter sample program on our Developer's site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/converting-and-merging-pdf-content#pdfxconverter
- *
  * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 public class PDFXConverter

--- a/DocumentConversion/ZUGFeRDConverter/src/main/java/com/datalogics/pdfl/samples/ZUGFeRDConverter.java
+++ b/DocumentConversion/ZUGFeRDConverter/src/main/java/com/datalogics/pdfl/samples/ZUGFeRDConverter.java
@@ -19,10 +19,7 @@ import com.datalogics.PDFL.PDFAConvertResult;
  * For more detail see the description of the ZUGFeRDConverter sample program on our Developer’s site,
  * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/converting-and-merging-pdf-content/#zugferdconverter
  *
- * Copyright (c) 2007-2019, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class ZUGFeRDConverter

--- a/DocumentOptimization/PDFOptimize/src/main/java/com/datalogics/pdfl/samples/PDFOptimize.java
+++ b/DocumentOptimization/PDFOptimize/src/main/java/com/datalogics/pdfl/samples/PDFOptimize.java
@@ -17,14 +17,7 @@ import com.datalogics.PDFL.*;
  * to suit your applications needs and drop such content to achieve better compression if you already
  * know it's unnecessary.
  * 
- * For more detail see the description of the PDFOptimizer sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/using-the-pdf-optimizer-to-manage-the-size-of-pdf-documents
- * 
- * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Images/DocToImages/src/main/java/com/datalogics/pdfl/samples/DocToImages.java
+++ b/Images/DocToImages/src/main/java/com/datalogics/pdfl/samples/DocToImages.java
@@ -6,15 +6,7 @@ package com.datalogics.pdfl.samples;
  * one per page. You can also create a multi-page TIFF file. This program requires that you enter 
  * formatting values manually at the command line. 
  *
- * For more detail, and information about the command line parameters, see the description of the DocToImages
- * sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/converting-pdf-pages-to-images
- * 
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/EPSSeparations/src/main/java/com/datalogics/pdfl/samples/EPSSeparations.java
+++ b/Images/EPSSeparations/src/main/java/com/datalogics/pdfl/samples/EPSSeparations.java
@@ -9,13 +9,7 @@ import com.datalogics.PDFL.*;
  * This sample demonstrates working with color separations with Encapsulated PostScript (EPS) graphics
  * from a PDF file.
  *
- * For more detail see the description of the EPSSeparations sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/manipulating-graphics-and-separating-colors-for-images#epsseparations
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/GetSeparatedImages/src/main/java/com/datalogics/pdfl/samples/GetSeparatedImages.java
+++ b/Images/GetSeparatedImages/src/main/java/com/datalogics/pdfl/samples/GetSeparatedImages.java
@@ -15,13 +15,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
 /*
  * This sample demonstrates drawing a list of grayscale separations from a PDF file to multi-paged TIFF file.
  *
- * For more detail see the description of the GetSeparatedImages sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/manipulating-graphics-and-separating-colors-for-images#getseparatedimages
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class GetSeparatedImages {

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArray.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArray.java
@@ -14,10 +14,8 @@ package com.datalogics.pdfl.samples;
  * ImageDisplayByteArray takes the content for the first page of a PDF file and stores it
  * in a Byte Array, and then exports that content from the Byte Array to the display viewer.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayDisplay.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayDisplay.java
@@ -1,10 +1,8 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-For complete copyright information, refer to:
-http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  */
 import java.awt.*;
 import java.awt.Point;

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayFrame.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayFrame.java
@@ -1,10 +1,8 @@
 /*
  * ImageDisplayByateArrayFrame.java
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved. 
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDCancelProc.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDCancelProc.java
@@ -1,10 +1,7 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved. 
-
-For complete copyright information, refer to:
-http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
  */
 import java.awt.*;
 import java.awt.Point;

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDRenderProgressProc.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDRenderProgressProc.java
@@ -1,12 +1,8 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2007-2016, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
  */
 
 import com.datalogics.PDFL.RenderProgressProc;

--- a/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ExportDocImage.java
+++ b/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ExportDocImage.java
@@ -13,10 +13,7 @@ import com.datalogics.PDFL.PageImageParams;
 import com.datalogics.PDFL.RenderIntent;
 
 /*
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class ExportDocImage {

--- a/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ImageEmbedICCProfile.java
+++ b/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ImageEmbedICCProfile.java
@@ -15,13 +15,7 @@ import com.datalogics.PDFL.PDFStream;
  * The program sets up how the output will be rendered and generates a TIF image file or
  * series of TIF files as output.
  * 
- * For more detail see the description of the ImageEmbedICCProfile sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/exporting-images-from-pdf-files/#imageembediccprofile
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ExportDocumentImages.java
+++ b/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ExportDocumentImages.java
@@ -3,10 +3,7 @@ package com.datalogics.pdfl.samples;
 import com.datalogics.PDFL.*;
 
 /*
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ImageExport.java
+++ b/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ImageExport.java
@@ -11,13 +11,7 @@ package com.datalogics.pdfl.samples;
  * sets of graphics files for those three images. The sample program ignores text, parsing the
  * PDF syntax to identify any raster or vector images found on every page.
  *
- * For more detail see the description of the ImageExport sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/exporting-images-from-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExtraction/src/main/java/com/datalogics/pdfl/samples/ImageExtraction.java
+++ b/Images/ImageExtraction/src/main/java/com/datalogics/pdfl/samples/ImageExtraction.java
@@ -7,14 +7,8 @@ package com.datalogics.pdfl.samples;
  * images from the PDF file and copies them to a separate set of graphics files in the
  * same directory. Vector images, such as clip art, will not be exported.
  * 
- * For more detail see the description of the ImageExtraction sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/exporting-images-from-pdf-files/#imageextraction
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageFromBufferedImage/src/main/java/com/datalogics/pdfl/samples/ImageFromBufferedImage.java
+++ b/Images/ImageFromBufferedImage/src/main/java/com/datalogics/pdfl/samples/ImageFromBufferedImage.java
@@ -20,13 +20,7 @@ import com.datalogics.PDFL.SaveFlags;
  * This sample shows how to create an image object in a PDF document by drawing a graphic from 
  * memory, rather than from another PDF document.
  *
- * For more detail see the description of this sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/importing-images-into-pdf-files/
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageFromByteArray/src/main/java/com/datalogics/pdfl/samples/ImageFromByteArray.java
+++ b/Images/ImageFromByteArray/src/main/java/com/datalogics/pdfl/samples/ImageFromByteArray.java
@@ -24,10 +24,7 @@ import com.datalogics.PDFL.SaveFlags;
 * 
 * When you run the program it will generate a single PDF as an output file.
 *
-* Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
-*
-* For complete copyright information, refer to:
-* http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+* Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
 *
 */
 

--- a/Images/ImageImport/src/main/java/com/datalogics/pdfl/samples/ImageImport.java
+++ b/Images/ImageImport/src/main/java/com/datalogics/pdfl/samples/ImageImport.java
@@ -7,10 +7,7 @@
  * The sample has two optional arguments, one a JPG image file, and the other the name of the default PDF output file.
  * The program imports the JPG file into a PDF and saves it to an output PDF file.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageResampling/src/main/java/com/datalogics/pdfl/samples/ImageResampling.java
+++ b/Images/ImageResampling/src/main/java/com/datalogics/pdfl/samples/ImageResampling.java
@@ -9,14 +9,8 @@ package com.datalogics.pdfl.samples;
  * used to reduce the resolution of an image or series of images, to make them smaller. As a result
  * the process makes the PDF document smaller, too.
  *
- * For more detail see the description of the ImageResampling sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
  *
- * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2008-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/RasterizePage/src/main/java/com/datalogics/pdfl/samples/RasterizePage.java
+++ b/Images/RasterizePage/src/main/java/com/datalogics/pdfl/samples/RasterizePage.java
@@ -27,10 +27,7 @@ public class RasterizePage {
 	 * 3. An output image file with content drawn from an unrotated PDF page, but that contains only the top half of
 	 *    the original page.
 	 *
-	 * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
-	 *
-	 * For complete copyright information, refer to:
-	 * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+	 * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
 	 *
 	 */
 	
@@ -72,7 +69,7 @@ public class RasterizePage {
             pip.setPageDrawFlags(EnumSet.of(DrawFlags.USE_ANNOT_FACES));
 
             // Set the PixelWidth to be exactly 400 pixels.
-            // We don't need to set the PixelHeight, as DLE will calculate
+            // We don't need to set the PixelHeight, as the Library will calculate
             // this for us automatically based on the PixelWidth and resolution.
             //
             // If you'd like a specific height, you can specify that too.
@@ -193,7 +190,7 @@ public class RasterizePage {
     {
         // Create a PageImageParams with the default settings and set
         // the color space as appropriate.
-        // We'll let DLE decide the final pixel dimensions of
+        // We'll let the Library decide the final pixel dimensions of
         // the bitmap, so we won't change these settings from the default.
 
         PageImageParams pip = new PageImageParams();

--- a/InformationExtraction/ListBookmarks/src/main/java/com/datalogics/pdfl/samples/ListBookmarks.java
+++ b/InformationExtraction/ListBookmarks/src/main/java/com/datalogics/pdfl/samples/ListBookmarks.java
@@ -3,13 +3,7 @@ package com.datalogics.pdfl.samples;
 * 
  * This sample finds and describes the bookmarks included in a PDF document.
  * 
- * For more detail see the description of the List sample programs, and ListBookmarks, on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import java.io.BufferedReader;

--- a/InformationExtraction/ListFonts/src/main/java/com/datalogics/pdfl/samples/ListFonts.java
+++ b/InformationExtraction/ListFonts/src/main/java/com/datalogics/pdfl/samples/ListFonts.java
@@ -4,20 +4,14 @@ import com.datalogics.PDFL.*;
 import java.util.*;
 /*
  * 
- * A sample which demonstrates the use of the DLE API to list
+ * A sample which demonstrates how to list
  * the set of available fonts.
  * 
  * This sample lists all of the fonts available for use on the machine where the ListFont program is run.
  * The font name appears with the type, such as Type0, Type1, or TrueType, and the encoding method,
  * such as WinAnsiEncoding.
  * 
- * For more detail see the description of the List sample programs, and ListFont, on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 public class ListFonts {

--- a/InformationExtraction/ListInfo/src/main/java/com/datalogics/pdfl/samples/ListInfo.java
+++ b/InformationExtraction/ListInfo/src/main/java/com/datalogics/pdfl/samples/ListInfo.java
@@ -15,14 +15,8 @@ import com.datalogics.PDFL.*;
  * 
  * The results are exported to a PDF output document.
  * 
- * For more detail see the description of the List sample programs, and ListInfo, on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListLayers/src/main/java/com/datalogics/pdfl/samples/ListLayers.java
+++ b/InformationExtraction/ListLayers/src/main/java/com/datalogics/pdfl/samples/ListLayers.java
@@ -1,19 +1,12 @@
 package com.datalogics.pdfl.samples;
 /*
  * 
- * A sample which demonstrates the use of the DLE API to list the
+ * A sample which demonstrates how to list the
  * separate color layers of a PDF file.
  *
  * This sample searches for and lists the names of the color layers found in a PDF document. 
- *  
- * For more detail see the description of the List sample programs, and ListLayers, on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import java.io.BufferedReader;

--- a/InformationExtraction/ListPaths/src/main/java/com/datalogics/pdfl/samples/ListPaths.java
+++ b/InformationExtraction/ListPaths/src/main/java/com/datalogics/pdfl/samples/ListPaths.java
@@ -26,15 +26,8 @@ import com.datalogics.PDFL.Segment;
  * This sample searches for and lists the contents of paths found in an existing PDF document.
  * Paths in PDF documents, or clipping paths, define the boundaries for art or graphics.
  * 
- * For more detail see the description of the List sample programs, and ListPaths, on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  */
 public class ListPaths {
 

--- a/InformationExtraction/Metadata/src/main/java/com/datalogics/pdfl/samples/Metadata.java
+++ b/InformationExtraction/Metadata/src/main/java/com/datalogics/pdfl/samples/Metadata.java
@@ -17,17 +17,12 @@ import org.w3c.dom.NodeList;
 /*
  * 
  * This sample shows how to view and edit metadata for a PDF document. The metadata values appear on the Properties
- * window in Adobe Reader and Adobe Acrobat. Click File/Properties, and then click Additional Metadata.
+ * window of a PDF Viewer. Click File/Properties, and then click Additional Metadata.
  *
- * For more detail see the description of the Metadata sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files#metadata
- * 
  *
  * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
+==
  */
 public class Metadata {
 

--- a/OpticalCharacterRecognition/AddTextToDocument/src/main/java/com/datalogics/pdfl/samples/AddTextToDocument.java
+++ b/OpticalCharacterRecognition/AddTextToDocument/src/main/java/com/datalogics/pdfl/samples/AddTextToDocument.java
@@ -24,13 +24,7 @@ import com.datalogics.PDFL.Group;
  * Process a document using the optical character recognition engine.
  * Then place the image and the processed text in an output pdf
  * 
- * For more detail see the description of AddTextToDocument on our Developers site, 
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/optical-character-recognition/
- * 
- * Copyright (c) 2007-2019, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/AddTextToImage/src/main/java/com/datalogics/pdfl/samples/AddTextToImage.java
+++ b/OpticalCharacterRecognition/AddTextToImage/src/main/java/com/datalogics/pdfl/samples/AddTextToImage.java
@@ -22,13 +22,7 @@ import com.datalogics.PDFL.SaveFlags;
  * The sample uses an image as input which will be processed by the optical character recognition engine.
  * We will then place the image and the processed text in an output pdf
  * 
- * For more detail see the description of AddTextToImage, on our Developers site, 
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/optical-character-recognition/
- * 
- * Copyright (c) 2007-2019, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Other/MemoryFileSystem/src/main/java/com/datalogics/pdfl/samples/MemoryFileSystem.java
+++ b/Other/MemoryFileSystem/src/main/java/com/datalogics/pdfl/samples/MemoryFileSystem.java
@@ -15,14 +15,11 @@ import com.datalogics.PDFL.TempStoreType;
  * This sample demonstrates how to initialize and use RAM memory instead of the local
  * hard disk to save temporary files, in order to save processing time.
  * 
- * The program sets the DefaultTempStore property of the Adobe PDF Library object to
+ * The program sets the DefaultTempStore property of the Library object to
  * TempStoreType.Memory. The program can also set a maximum amount of RAM to use by
  * applying a value to the DefaultTempStoreMemLimit property.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Other/StreamIO/src/main/java/com/datalogics/pdfl/samples/StreamIO.java
+++ b/Other/StreamIO/src/main/java/com/datalogics/pdfl/samples/StreamIO.java
@@ -16,13 +16,7 @@ import com.datalogics.PDFL.*;
  * 
  * This program is similar to ImagefromStream, but in this example the PDF file streams hold text.
  *
- * For more detail see the description of the StreamIO sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/exporting-images-from-pdf-files/#streamio
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -71,7 +65,7 @@ public class StreamIO {
         static void readFromStream(String filename, String output) throws java.io.IOException {
             //First we create InputStream from the file.
             InputStream in = new FileInputStream(filename);
-            //Second we create ImageInputStream that is required by DLE interface. 
+            //Second we create ImageInputStream as required by the interface.
             //We use MemoryCacheImageInputStream, this means that buffer will be cached in memory.
             //Another option is to use FileCacheImageInputStream with temporary file cache.
             ImageInputStream iin = new javax.imageio.stream.MemoryCacheImageInputStream(in);
@@ -98,13 +92,13 @@ public class StreamIO {
 	        Document doc = new Document(filename);
 
 		    // Add some content to the Document so there will be something to see.
-            doc.setCreator("DLE StreamIO Sample");	        
+            doc.setCreator("StreamIO Sample");
             Page p = doc.createPage(Document.BEFORE_FIRST_PAGE, new Rect(0, 0, 612, 792));
             addContentToPage(p);
             
             //First create OutputStream
             OutputStream out = new FileOutputStream(output);
-            //Second create ImageOutputStream that is required by DLE interface. 
+            //Second create ImageOutputStream as required by the interface. 
             //MemoryCacheImageOutputStream or FileCacheImageOutputStream can be used.
             ImageOutputStream ios = new javax.imageio.stream.MemoryCacheImageOutputStream(out); 
             //Save the document

--- a/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintCancelProc.java
+++ b/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintCancelProc.java
@@ -3,10 +3,7 @@ package com.datalogics.pdfl.samples;
  * 
  * A sample which demonstrates the use of a cancel callback in a print job.
  *  
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.PrintCancelProc;

--- a/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintProgressProc.java
+++ b/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintProgressProc.java
@@ -1,15 +1,10 @@
 package com.datalogics.pdfl.samples;
 /*
  * 
- * A sample which demonstrates the use of the DLE API to obtain information about
+ * A sample which demonstrates how to obtain information about
  * print job progress.
  * 
- * Copyright (c) 2007-2016, Datalogics, Inc. All rights reserved.
- *
- * The information and code in this sample is for the exclusive use of Datalogics
- * customers and evaluation users only.	 Datalogics permits you to use, modify and
- * distribute this file in accordance with the terms of your license agreement.
- * Sample code is for demonstrative purposes only and is not intended for production use.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PrintPDF.java
+++ b/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PrintPDF.java
@@ -14,13 +14,7 @@ import com.datalogics.PDFL.*;
  * computer in use. This program is useful in that it identifies the API you need to use to
  * print PDF files. It also generates a Postscript (PS) output file. 
  *
- * For more detail see the description of this sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/printing-pdf-files-and-generating-postscript-ps-files-from-pdf/
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -57,7 +51,7 @@ public class PrintPDF {
 		printParams.setExpandToFit(true);
 
 		// Printing with specified page ranges
-		// Uncomment next code to allow DLE printing with specified page ranges
+		// Uncomment next code to allow printing with specified page ranges
 
 		// List<PageRange> pageRanges = new ArrayList<PageRange>();
 
@@ -79,7 +73,7 @@ public class PrintPDF {
 		doc.printToFile(userParams, "PrintPDF_out.prn");
 
 
-		// Export as (DLE/PDFL composed) PostScript...
+		// Export as (PDFL composed) PostScript...
 		//
 		// PostScript files produced via this *export* method are suitable
 		// for Distillation, Normalization, etc. If a PostScript Printer
@@ -105,7 +99,7 @@ public class PrintPDF {
 		// Now let's, print directly to a printer (without ui)...
 		//
 		// Printed output from the following method is composed by the selected
-		// printer's driver; along with assistance from DLE / APDFL. The actual
+		// printer's driver; along with assistance from APDFL. The actual
 		// output format will vary (e.g., PCL, PostScript, XPS, etc.). PostScript
 		// files produced via a PostScript driver and this method are NOT suitable
 		// for Distillation, Normalization, etc. All output from the method below
@@ -125,32 +119,6 @@ public class PrintPDF {
 		userParams.useDefaultPrinter(doc);
 		//Print the document and report progress on-screen.
 		doc.print(userParams, new PGDPrintCancelProc(false), new PGDPrintProgressProc());
-
-
-		// Print to a printer
-		// For a list of the current print drivers available under WinNT, look at:
-		// HKEY_CURRENT_USER\Software\Microsoft\WindowsNT\CurrentVersion\Devices
-		// but some special virtual printers modify their ports, so pose a print dialog
-		// SetPageSize property and ShrinkToFit are incompatible. So we need to set SetPageSize to False
-		// to print to a printer in a proper way.
-		//userParams.getPrintParams().setSetPageSize(false);
-		//userParams.setShrinkToFit(true);
-
-		//if (userParams.posePrintDialog(doc))
-
-		// #if WIN32
-		// This sets the file name that the printer driver knows about
-		// userParams.inFileName = args[0];
-		// #endif
-		//{
-			// Added override of dialog box paper height and width
-			// because UseMediaBox seems to yield a printed product that more closely
-			// resembles what comes out of Acrobat.  This eliminates a number of
-			// print problems, including PCL blank page problems.
-			//userParams.setPaperHeight(PrintUserParams.USE_MEDIA_BOX);
-			//userParams.setPaperWidth(PrintUserParams.USE_MEDIA_BOX);
-		    //doc.print(userParams);
-		//}
 		
 		// this properly terminates the library, and is required
 		lib.delete();

--- a/Printing/PrintPDFGUI/src/main/java/com/datalogics/pdfl/samples/PrintPDFGUI.java
+++ b/Printing/PrintPDFGUI/src/main/java/com/datalogics/pdfl/samples/PrintPDFGUI.java
@@ -8,14 +8,8 @@ import com.datalogics.PDFL.*;
 /*
  * This sample demonstrates printing a PDF file. It is similar to PrintPDF, but this
  * program provides a user interface.
- * 
- * For more detail see the description of the PrintPDFGUI sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/printing-pdf-files-and-generating-postscript-ps-files-from-pdf
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -81,10 +75,6 @@ public class PrintPDFGUI extends JFrame
              // userParams.useDefaultPrinter(doc);
 
              {
-                 // Added override of dialog box paper height and width
-                 // because UseMediaBox seems to yield a printed product that more closely
-                 // resembles what comes out of Acrobat.  This eliminates a number of
-                 // print problems, including PCL blank page problems.
                  userParams.setPaperHeight(PrintUserParams.USE_MEDIA_BOX);
                  userParams.setPaperWidth(PrintUserParams.USE_MEDIA_BOX);
             	 doc.print(userParams);

--- a/Security/AddRegexRedaction/src/main/java/com/datalogics/pdfl/samples/AddRegexRedaction.java
+++ b/Security/AddRegexRedaction/src/main/java/com/datalogics/pdfl/samples/AddRegexRedaction.java
@@ -19,10 +19,7 @@ import java.util.List;
  * document that matches a user-supplied regular expression. When the sample finds the text it
  * will redact the phrase from the output document.
  * 
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Security/Redactions/src/main/java/com/datalogics/pdfl/samples/Redactions.java
+++ b/Security/Redactions/src/main/java/com/datalogics/pdfl/samples/Redactions.java
@@ -7,15 +7,9 @@ import com.datalogics.PDFL.*;
 /*
   * 
  * This sample shows how to redact a PDF document. The program opens an input PDF, searches for
- * specific words using the Adobe PDF Library WordFinder, and then removes these words from the text.
+ * specific words using the WordFinder, and then removes these words from the text.
  * 
- * For more detail see the description of the Redactions sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/redacting-text-from-a-pdf-document
- *
- * Copyright (c) 2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/AddGlyphs/src/main/java/com/datalogics/pdfl/samples/AddGlyphs.java
+++ b/Text/AddGlyphs/src/main/java/com/datalogics/pdfl/samples/AddGlyphs.java
@@ -24,14 +24,8 @@ import com.datalogics.PDFL.TextState;
  * Use this program to create a new PDF file and add glyphs to the page,
  * managing them by individual Glyph ID codes.
  * 
- * For more detail see the description of the AddGlyphs sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/adding-text-and-graphic-elements#addglyphs
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/AddUnicodeText/src/main/java/com/datalogics/pdfl/samples/AddUnicodeText.java
+++ b/Text/AddUnicodeText/src/main/java/com/datalogics/pdfl/samples/AddUnicodeText.java
@@ -4,13 +4,7 @@ package com.datalogics.pdfl.samples;
   * 
  * This sample program adds six lines of Unicode text to a PDF file, in six different languages.
  *
- * For more detail see the description of the AddUnicodeText sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/adding-text-and-graphic-elements#addunicodetext
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.Document;

--- a/Text/AddVerticalText/src/main/java/com/datalogics/pdfl/samples/AddVerticalText.java
+++ b/Text/AddVerticalText/src/main/java/com/datalogics/pdfl/samples/AddVerticalText.java
@@ -10,10 +10,7 @@ package com.datalogics.pdfl.samples;
  * The PDF output file presents multiple columns of vertical text. The characters appear in English as well as
  * Mandarin, Japanese, and Korean.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.Document;

--- a/Text/ListWords/src/main/java/com/datalogics/pdfl/samples/ListWords.java
+++ b/Text/ListWords/src/main/java/com/datalogics/pdfl/samples/ListWords.java
@@ -10,13 +10,7 @@ import com.datalogics.PDFL.*;
  * 
  * This sample lists the text for the words in a PDF document.
  * 
- * For more detail see the description of the List sample programs, and ListWords, on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/java-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/RegexExtractText/src/main/java/com/datalogics/pdfl/samples/RegexExtractText.java
+++ b/Text/RegexExtractText/src/main/java/com/datalogics/pdfl/samples/RegexExtractText.java
@@ -24,10 +24,7 @@ import org.json.JSONObject;
  * that matches a user-supplied regular expression. The output is a JSON file that
  * has the match information.
  *
- * Copyright (c) 2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2021-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/RegexTextSearch/src/main/java/com/datalogics/pdfl/samples/RegexTextSearch.java
+++ b/Text/RegexTextSearch/src/main/java/com/datalogics/pdfl/samples/RegexTextSearch.java
@@ -18,10 +18,7 @@ import java.util.List;
  * This sample shows how to search a PDF document using regex pattern matching. The program opens an input PDF, searches for
  * words using the Adobe PDF Library DocTextFinder, and then prints these words to the console.
  *
- * Copyright (c) 2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2021-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/TextExtract/src/main/java/com/datalogics/pdfl/samples/TextExtract.java
+++ b/Text/TextExtract/src/main/java/com/datalogics/pdfl/samples/TextExtract.java
@@ -16,10 +16,7 @@ import com.datalogics.PDFL.*;
  * PDF file is tagged or untagged. Tagging is used to make PDF files accessible
  * to the blind or to people with vision problems. 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 


### PR DESCRIPTION
Remove devsite links, all the information is now in this github repository for the samples.

Remove extra DL copyright devsite link which was uncessary.

Update through copyright of all samples.

Some recently created samples needed a through copyright, not just the current year.

Remove asterisks from markdown which had no effect.