### PR TITLE
Update all samples to use the 18.21.0 release

### DIFF
--- a/Annotations/Annotations/pom.xml
+++ b/Annotations/Annotations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/InkAnnotations/pom.xml
+++ b/Annotations/InkAnnotations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/LinkAnnotations/pom.xml
+++ b/Annotations/LinkAnnotations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/PolyLineAnnotations/pom.xml
+++ b/Annotations/PolyLineAnnotations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/PolygonAnnotations/pom.xml
+++ b/Annotations/PolygonAnnotations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/AddElements/pom.xml
+++ b/ContentCreation/AddElements/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/AddHeaderFooter/pom.xml
+++ b/ContentCreation/AddHeaderFooter/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/Clips/pom.xml
+++ b/ContentCreation/Clips/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/CreateBookmarks/pom.xml
+++ b/ContentCreation/CreateBookmarks/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/GradientShade/pom.xml
+++ b/ContentCreation/GradientShade/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithLabColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithLabColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/NameTrees/pom.xml
+++ b/ContentCreation/NameTrees/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/NumberTrees/pom.xml
+++ b/ContentCreation/NumberTrees/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/RemoteGoToActions/pom.xml
+++ b/ContentCreation/RemoteGoToActions/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/WriteNChannelTiff/pom.xml
+++ b/ContentCreation/WriteNChannelTiff/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/Actions/pom.xml
+++ b/ContentModification/Actions/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/AddCollection/pom.xml
+++ b/ContentModification/AddCollection/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/ChangeLayerConfiguration/pom.xml
+++ b/ContentModification/ChangeLayerConfiguration/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/ChangeLinkColors/pom.xml
+++ b/ContentModification/ChangeLinkColors/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/CreateLayer/pom.xml
+++ b/ContentModification/CreateLayer/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/ExtendedGraphicStates/pom.xml
+++ b/ContentModification/ExtendedGraphicStates/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/FlattenTransparency/pom.xml
+++ b/ContentModification/FlattenTransparency/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/LaunchActions/pom.xml
+++ b/ContentModification/LaunchActions/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/MergePDF/pom.xml
+++ b/ContentModification/MergePDF/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/PDFObject/pom.xml
+++ b/ContentModification/PDFObject/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/PageLabels/pom.xml
+++ b/ContentModification/PageLabels/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/UnderlinesAndHighlights/pom.xml
+++ b/ContentModification/UnderlinesAndHighlights/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/Watermark/pom.xml
+++ b/ContentModification/Watermark/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/DisplayPDF/pom.xml
+++ b/Display/DisplayPDF/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/ImageDisplay/pom.xml
+++ b/Display/ImageDisplay/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/JavaViewer/pom.xml
+++ b/Display/JavaViewer/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/PDFObjectExplorer/pom.xml
+++ b/Display/PDFObjectExplorer/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/ColorConvertDocument/pom.xml
+++ b/DocumentConversion/ColorConvertDocument/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/ConvertToOffice/pom.xml
+++ b/DocumentConversion/ConvertToOffice/pom.xml
@@ -26,32 +26,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/CreateDocFromXPS/pom.xml
+++ b/DocumentConversion/CreateDocFromXPS/pom.xml
@@ -39,32 +39,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/FacturXConverter/pom.xml
+++ b/DocumentConversion/FacturXConverter/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/PDFAConverter/pom.xml
+++ b/DocumentConversion/PDFAConverter/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/PDFXConverter/pom.xml
+++ b/DocumentConversion/PDFXConverter/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/ZUGFeRDConverter/pom.xml
+++ b/DocumentConversion/ZUGFeRDConverter/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentOptimization/PDFOptimize/pom.xml
+++ b/DocumentOptimization/PDFOptimize/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/DocToImages/pom.xml
+++ b/Images/DocToImages/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/DrawSeparations/pom.xml
+++ b/Images/DrawSeparations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/EPSSeparations/pom.xml
+++ b/Images/EPSSeparations/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/GetSeparatedImages/pom.xml
+++ b/Images/GetSeparatedImages/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageDisplayByteArray/pom.xml
+++ b/Images/ImageDisplayByteArray/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageEmbedICCProfile/pom.xml
+++ b/Images/ImageEmbedICCProfile/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageExport/pom.xml
+++ b/Images/ImageExport/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageExtraction/pom.xml
+++ b/Images/ImageExtraction/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageFromBufferedImage/pom.xml
+++ b/Images/ImageFromBufferedImage/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageFromByteArray/pom.xml
+++ b/Images/ImageFromByteArray/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageImport/pom.xml
+++ b/Images/ImageImport/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageResampling/pom.xml
+++ b/Images/ImageResampling/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/RasterizePage/pom.xml
+++ b/Images/RasterizePage/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListBookmarks/pom.xml
+++ b/InformationExtraction/ListBookmarks/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListFonts/pom.xml
+++ b/InformationExtraction/ListFonts/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListInfo/pom.xml
+++ b/InformationExtraction/ListInfo/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListLayers/pom.xml
+++ b/InformationExtraction/ListLayers/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListPaths/pom.xml
+++ b/InformationExtraction/ListPaths/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/Metadata/pom.xml
+++ b/InformationExtraction/Metadata/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/AddTextToDocument/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToDocument/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/AddTextToImage/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToImage/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Other/MemoryFileSystem/pom.xml
+++ b/Other/MemoryFileSystem/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Other/StreamIO/pom.xml
+++ b/Other/StreamIO/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Printing/PrintPDF/pom.xml
+++ b/Printing/PrintPDF/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Printing/PrintPDFGUI/pom.xml
+++ b/Printing/PrintPDFGUI/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/AddRegexRedaction/pom.xml
+++ b/Security/AddRegexRedaction/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/Redactions/pom.xml
+++ b/Security/Redactions/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/AddGlyphs/pom.xml
+++ b/Text/AddGlyphs/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/AddUnicodeText/pom.xml
+++ b/Text/AddUnicodeText/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/AddVerticalText/pom.xml
+++ b/Text/AddVerticalText/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/ListWords/pom.xml
+++ b/Text/ListWords/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/RegexExtractText/pom.xml
+++ b/Text/RegexExtractText/pom.xml
@@ -56,32 +56,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/RegexTextSearch/pom.xml
+++ b/Text/RegexTextSearch/pom.xml
@@ -56,32 +56,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/TextExtract/pom.xml
+++ b/Text/TextExtract/pom.xml
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.20.0</version>
+      <version>18.21.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>


### PR DESCRIPTION
All samples will use the 18.21.0 release. _This should not be merged until the 18.21.0 release is available on Maven Central._