### PR TITLE
Revert the ConvertToOffice sample to use the 18.20.0 release

### DIFF
--- a/DocumentConversion/ConvertToOffice/pom.xml
+++ b/DocumentConversion/ConvertToOffice/pom.xml
@@ -26,32 +26,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.21.0</version>
+      <version>18.20.0</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.21.0</version>
+      <version>18.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.21.0</version>
+      <version>18.20.0</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.21.0</version>
+      <version>18.20.0</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>18.21.0</version>
+      <version>18.20.0</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>


### PR DESCRIPTION
A bug was discovered in the 18.21.0 release that prevents the ConvertToOffice sample from working. As a temporary fix we are reverting this sample to use 18.20.0, which is known to work.

The bug will be fixed in an upcoming release, at which time this sample will be updated to use that release.