### PR TITLE
Correct package name for AddQRCode sample

### DIFF
--- a/ContentModification/AddQRCode/src/main/java/com/datalogics/pdfl/samples/AddQRCode.java
+++ b/ContentModification/AddQRCode/src/main/java/com/datalogics/pdfl/samples/AddQRCode.java
@@ -1,4 +1,4 @@
-package com.datalogics.pdfl.samples.ContentModification.AddQRCode;
+package com.datalogics.pdfl.samples;
 
 
 import java.util.ArrayList;


### PR DESCRIPTION
QA was having issues running the AddQRCode sample because IntelliJ couldn't find the main class. To fix the issue, we have to correct the package name for the sample.