### PR TITLE
Fix render flag setting.

### DIFF
--- a/Images/GetSeparatedImages/src/main/java/com/datalogics/pdfl/samples/GetSeparatedImages.java
+++ b/Images/GetSeparatedImages/src/main/java/com/datalogics/pdfl/samples/GetSeparatedImages.java
@@ -15,7 +15,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
 /*
  * This sample demonstrates drawing a list of grayscale separations from a PDF file to multi-paged TIFF file.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2024, Datalogics, Inc. All rights reserved.
  *
  */
 public class GetSeparatedImages {
@@ -49,6 +49,7 @@ public class GetSeparatedImages {
             }
 
             PageImageParams pip = new PageImageParams();
+            pip.setPageDrawFlags(EnumSet.of(DrawFlags.USE_ANNOT_FACES));
             pip.setHorizontalResolution(300.0);
             pip.setVerticalResolution(300.0);
 

--- a/Images/OutputPreview/src/main/java/com/datalogics/pdfl/samples/OutputPreview.java
+++ b/Images/OutputPreview/src/main/java/com/datalogics/pdfl/samples/OutputPreview.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
  * This sample demonstrates creating an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
  *
  * 
- * Copyright (c)2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c)2023-2024, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -83,6 +83,7 @@ public class OutputPreview {
             }
 
             PageImageParams pip = new PageImageParams();
+            pip.setPageDrawFlags(EnumSet.of(DrawFlags.USE_ANNOT_FACES));
             pip.setHorizontalResolution(300.0);
             pip.setVerticalResolution(300.0);
 


### PR DESCRIPTION
Because Spot Colorants may only be part of Annotation appearances, to do a proper DeviceN rendering of all colorants this needs to be set. Otherwise we collect all the spot colorants including those of Annotation appearances and setup our DeviceN rendering with it....but at the same time we tell PDFL with our render flags "don't consider them", leading to scrambled output.