### PR TITLE
Don't set the bypass parameter.

### DIFF
--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageCache.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageCache.java
@@ -285,7 +285,6 @@ public class PageCache implements PageModel {
             params.setFlags(EnumSet.of(DrawFlags.DO_LAZY_ERASE, DrawFlags.USE_ANNOT_FACES));
             params.setSmoothFlags(EnumSet.of(SmoothFlags.IMAGE, SmoothFlags.LINE_ART, SmoothFlags.TEXT));
             params.setEnableBlackPointCompensation(true);
-            params.setBypassCopyPerm(true);
             // Draw. We get a byte array that has the samples in left-right top-bottom order. may throw OutOfMemoryError
             byte[] values = null;
             try {


### PR DESCRIPTION
Customer found a stride error opening a particular PDF but more generally it seems to happen for any PDF because rendering fails.

If the bypass copy permission is set, but the license string hasn't been set, it errors out accordingly.

The stock sample shouldn't be setting this.