### PR TITLE
Fix a semgrep report by fixing the code.

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -138,9 +138,13 @@ def remove_last_path_entry():
 
 
 def execute_java_sample(target_dir, sample_name, full_path, apdfl_key):
-    command = str(f'java -Djava.library.path={target_dir} -jar target/{sample_name}-1.0-SNAPSHOT-jar-with-dependencies.jar')
-
-    process = subprocess.Popen(command, shell=True, cwd=full_path,
+    command = [
+        'java',
+        f'-Djava.library.path={target_dir}',
+        '-jar',
+        f'target/{sample_name}-1.0-SNAPSHOT-jar-with-dependencies.jar'
+    ]
+    process = subprocess.Popen(command, shell=False, cwd=full_path,
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     process.stdin.write(apdfl_key.encode() + b'\n')


### PR DESCRIPTION
Resolve semgrep report by using a list of strings as the argument to subprocess.Popen, and set shell to False to prevent string intrepetation.

CWE-78

Description
Found subprocess function Popen with shell=True. This is dangerous because this call will spawn the command using a shell process. Doing so propagates current shell settings and variables, which makes it much easier for a malicious actor to execute commands. Use shell=False instead.