### PR TITLE
APDFL-6489 Update OCR samples to use the language package

### DIFF
--- a/OpticalCharacterRecognition/AddTextToDocument/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToDocument/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>LATEST</version>
       <type>zip</type>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/AddTextToDocument/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToDocument/pom.xml
@@ -79,6 +79,12 @@
       <version>LATEST</version>
       <classifier>javadoc</classifier>
     </dependency>
+    <dependency>
+      <groupId>com.datalogics.pdfl</groupId>
+      <artifactId>ocr-data</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>zip</type>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>
@@ -127,6 +133,23 @@
                   <classifier>${jni.classifier}</classifier>
                   <type>zip</type>
                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-ocr-data</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                   <groupId>com.datalogics.pdfl</groupId>
+                   <artifactId>ocr-data</artifactId>
+                   <type>zip</type>
+                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/OpticalCharacterRecognition/AddTextToImage/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToImage/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>LATEST</version>
       <type>zip</type>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/AddTextToImage/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToImage/pom.xml
@@ -79,6 +79,12 @@
       <version>LATEST</version>
       <classifier>javadoc</classifier>
     </dependency>
+    <dependency>
+      <groupId>com.datalogics.pdfl</groupId>
+      <artifactId>ocr-data</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>zip</type>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>
@@ -127,6 +133,23 @@
                   <classifier>${jni.classifier}</classifier>
                   <type>zip</type>
                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-ocr-data</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                   <groupId>com.datalogics.pdfl</groupId>
+                   <artifactId>ocr-data</artifactId>
+                   <type>zip</type>
+                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/OpticalCharacterRecognition/OCRDocument/pom.xml
+++ b/OpticalCharacterRecognition/OCRDocument/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>LATEST</version>
       <type>zip</type>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/OCRDocument/pom.xml
+++ b/OpticalCharacterRecognition/OCRDocument/pom.xml
@@ -79,6 +79,12 @@
       <version>LATEST</version>
       <classifier>javadoc</classifier>
     </dependency>
+    <dependency>
+      <groupId>com.datalogics.pdfl</groupId>
+      <artifactId>ocr-data</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>zip</type>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>
@@ -127,6 +133,23 @@
                   <classifier>${jni.classifier}</classifier>
                   <type>zip</type>
                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-ocr-data</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                   <groupId>com.datalogics.pdfl</groupId>
+                   <artifactId>ocr-data</artifactId>
+                   <type>zip</type>
+                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>


### PR DESCRIPTION
Since moving the `.tranieddata` files to their own package, the OCR samples need to include this as a dependency.
