### PR TITLE
APDFL-6637: Update Java samples for APDFL 21

### DIFF
--- a/Annotations/Annotations/pom.xml
+++ b/Annotations/Annotations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>Annotations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/Annotations/src/main/java/com/datalogics/pdfl/samples/Annotations.java
+++ b/Annotations/Annotations/src/main/java/com/datalogics/pdfl/samples/Annotations.java
@@ -11,7 +11,7 @@ import com.datalogics.PDFL.Page;
  * 
  * This sample demonstrates how to find and describe annotations in an existing PDF document.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class Annotations {

--- a/Annotations/InkAnnotations/pom.xml
+++ b/Annotations/InkAnnotations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>InkAnnotations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/InkAnnotations/src/main/java/com/datalogics/pdfl/samples/InkAnnotations.java
+++ b/Annotations/InkAnnotations/src/main/java/com/datalogics/pdfl/samples/InkAnnotations.java
@@ -13,7 +13,7 @@ import java.util.List;
  * This sample creates and adds a new Ink annotation to a PDF document. An Ink annotation is a freeform line,
  * similar to what you would create with a pen, or with a stylus on a mobile device.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/LinkAnnotations/pom.xml
+++ b/Annotations/LinkAnnotations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>LinkAnnotations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/LinkAnnotations/src/main/java/com/datalogics/pdfl/samples/LinkAnnotations.java
+++ b/Annotations/LinkAnnotations/src/main/java/com/datalogics/pdfl/samples/LinkAnnotations.java
@@ -15,7 +15,7 @@ import com.datalogics.PDFL.ViewDestination;
  * 
  * This program creates a PDF file with an embedded hyperlink, which takes the viewer to the second page of the document.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class LinkAnnotations {

--- a/Annotations/PolyLineAnnotations/pom.xml
+++ b/Annotations/PolyLineAnnotations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PolyLineAnnotations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/PolyLineAnnotations/src/main/java/com/datalogics/pdfl/samples/PolyLineAnnotations.java
+++ b/Annotations/PolyLineAnnotations/src/main/java/com/datalogics/pdfl/samples/PolyLineAnnotations.java
@@ -11,7 +11,7 @@ import com.datalogics.PDFL.*;
  * This program generates a PDF output file with a line shape (an angle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/PolygonAnnotations/pom.xml
+++ b/Annotations/PolygonAnnotations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PolygonAnnotations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Annotations/PolygonAnnotations/src/main/java/com/datalogics/pdfl/samples/PolygonAnnotations.java
+++ b/Annotations/PolygonAnnotations/src/main/java/com/datalogics/pdfl/samples/PolygonAnnotations.java
@@ -11,7 +11,7 @@ import com.datalogics.PDFL.*;
  * This program generates a PDF output file with a polygon shape (a triangle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/AddElements/pom.xml
+++ b/ContentCreation/AddElements/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddElements</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AECancelProc.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AECancelProc.java
@@ -3,7 +3,7 @@
  * A sample which demonstrates how to create a new
  * PDF file and add two pages containing a series of Path and Text elements
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEProgressMonitor.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEProgressMonitor.java
@@ -3,7 +3,7 @@
  * A sample which demonstrates how to create a new
  * PDF file and add two pages containing a series of Path and Text elements
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEReportProc.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AEReportProc.java
@@ -4,7 +4,7 @@
  * A sample which demonstrates how to create a new
  * PDF file and add two pages containing a series of Path and Text elements
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AddElements.java
+++ b/ContentCreation/AddElements/src/main/java/com/datalogics/pdfl/samples/AddElements.java
@@ -7,7 +7,7 @@ package com.datalogics.pdfl.samples;
  * The third page features a rectangle and a curved design. Use this sample for ideas on how
  * to draw an image on a PDF page.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.*;

--- a/ContentCreation/AddHeaderFooter/pom.xml
+++ b/ContentCreation/AddHeaderFooter/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddHeaderFooter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/AddHeaderFooter/src/main/java/com/datalogics/pdfl/samples/AddHeaderFooter.java
+++ b/ContentCreation/AddHeaderFooter/src/main/java/com/datalogics/pdfl/samples/AddHeaderFooter.java
@@ -4,7 +4,7 @@ package com.datalogics.pdfl.samples;
  *
  * This sample demonstrates creating a new PDF document with a Header and Footer.
  * 
- * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2022-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.Document;

--- a/ContentCreation/Clips/pom.xml
+++ b/ContentCreation/Clips/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>Clips</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/Clips/src/main/java/com/datalogics/pdfl/samples/Clips.java
+++ b/ContentCreation/Clips/src/main/java/com/datalogics/pdfl/samples/Clips.java
@@ -18,7 +18,7 @@ import com.datalogics.PDFL.*;
 /*
  * This sample demonstrates working with Clip objects. A clipping path is used to edit the borders of a graphics object.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/CreateBookmarks/pom.xml
+++ b/ContentCreation/CreateBookmarks/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>CreateBookmarks</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/CreateBookmarks/src/main/java/com/datalogics/pdfl/samples/CreateBookmarks.java
+++ b/ContentCreation/CreateBookmarks/src/main/java/com/datalogics/pdfl/samples/CreateBookmarks.java
@@ -25,7 +25,7 @@ import com.datalogics.PDFL.*;
  * parts of the page. The last three, Child1, 2, and 3, are dummy bookmarks that do not respond when you
  * click on them.  They demonstrate how to rearrange existing bookmarks.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class CreateBookmarks 

--- a/ContentCreation/GradientShade/pom.xml
+++ b/ContentCreation/GradientShade/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>GradientShade</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/GradientShade/src/main/java/com/datalogics/pdfl/samples/GradientShade.java
+++ b/ContentCreation/GradientShade/src/main/java/com/datalogics/pdfl/samples/GradientShade.java
@@ -10,7 +10,7 @@ import com.datalogics.PDFL.*;
  * This sample demonstrates changing the shading of an image on a PDF document page. The image gradually
  * changes from black on the left side of the image, to red on the right side.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class GradientShade {

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithCalGrayColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalGrayColorSpace.java
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalGrayColorSpace.java
@@ -2,7 +2,7 @@
  * 
  * Demonstrates working with the Calibrated Gray Space (CaLGray), based on the CIE color space.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithCalRGBColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalRGBColorSpace.java
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithCalRGBColorSpace.java
@@ -3,7 +3,7 @@
  * Demonstrates working with the Calibrated RGB Color Space, based on the CIE color space.
  * A, B, and C represent red, blue, and green color values.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithDeviceNColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithDeviceNColorSpace.java
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithDeviceNColorSpace.java
@@ -8,7 +8,7 @@ import java.util.List;
 /*
  * This sample demonstrates creating a file containing a DeviceN color space.
  *
- * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2008-2026, Datalogics, Inc. All rights reserved.
 *
  */
 public class MakeDocWithDeviceNColorSpace {

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithICCBasedColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithICCBasedColorSpace.java
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithICCBasedColorSpace.java
@@ -9,7 +9,7 @@ import java.util.EnumSet;
 /*
  * This sample demonstrates creating a file containing an ICC-based color space.
  *
- * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2008-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithICCBasedColorSpace {

--- a/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithIndexedColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithIndexedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithIndexedColorSpace.java
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithIndexedColorSpace.java
@@ -26,7 +26,7 @@ import com.datalogics.PDFL.TextState;
  * to reduce the amount of system memory used for processing images when a limited
  * number of colors are needed.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithIndexedColorSpace {

--- a/ContentCreation/MakeDocWithLabColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithLabColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithLabColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithLabColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithLabColorSpace.java
+++ b/ContentCreation/MakeDocWithLabColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithLabColorSpace.java
@@ -25,7 +25,7 @@ import java.util.List;
  * CIE XYZ color space, but it includes a dimension L, for lightness,
  * along with a and b coordinates, to define the color.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithLabColorSpace {

--- a/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MakeDocWithSeparationColorSpace</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/MakeDocWithSeparationColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithSeparationColorSpace.java
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/src/main/java/com/datalogics/pdfl/samples/MakeDocWithSeparationColorSpace.java
@@ -8,7 +8,7 @@ import java.util.List;
 /*
 * This sample demonstrates creating a PDF document that uses a Separation color space.
  *
- * Copyright (c) 2008-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2008-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class MakeDocWithSeparationColorSpace {

--- a/ContentCreation/NameTrees/pom.xml
+++ b/ContentCreation/NameTrees/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>NameTrees</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/NameTrees/src/main/java/com/datalogics/pdfl/samples/NameTrees.java
+++ b/ContentCreation/NameTrees/src/main/java/com/datalogics/pdfl/samples/NameTrees.java
@@ -20,7 +20,7 @@ import com.datalogics.PDFL.*;
  * dictionary, instead of using a code value as a key to identify an object, a name tree
  * uses names as keys to map to data objects. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/NumberTrees/pom.xml
+++ b/ContentCreation/NumberTrees/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>NumberTrees</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/NumberTrees/src/main/java/com/datalogics/pdfl/samples/NumberTrees.java
+++ b/ContentCreation/NumberTrees/src/main/java/com/datalogics/pdfl/samples/NumberTrees.java
@@ -9,7 +9,7 @@ import com.datalogics.PDFL.*;
  * keys used in a number tree are integers, rather than character strings, and these keys are sorted
  * in ascending numerical order. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/RemoteGoToActions/pom.xml
+++ b/ContentCreation/RemoteGoToActions/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>RemoteGoToActions</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/RemoteGoToActions/src/main/java/com/datalogics/pdfl/samples/RemoteGoToActions.java
+++ b/ContentCreation/RemoteGoToActions/src/main/java/com/datalogics/pdfl/samples/RemoteGoToActions.java
@@ -21,7 +21,7 @@ import com.datalogics.PDFL.RemoteGoToAction;
  * RemoteGoToActions differs from LaunchActions in that it includes a RemoteDestination object.
  * This object describes the rectangle used in the PDF file in a series of statements at the command prompt. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/WriteNChannelTiff/pom.xml
+++ b/ContentCreation/WriteNChannelTiff/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>WriteNChannelTiff</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentCreation/WriteNChannelTiff/src/main/java/com/datalogics/pdfl/samples/WriteNChannelTiff.java
+++ b/ContentCreation/WriteNChannelTiff/src/main/java/com/datalogics/pdfl/samples/WriteNChannelTiff.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
  * This sample generates a multi-page TIFF file, selecting graphics drawn from
  * the first page of the PDF document provided.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/Actions/pom.xml
+++ b/ContentModification/Actions/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>Actions</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/Actions/src/main/java/com/datalogics/pdfl/samples/Actions.java
+++ b/ContentModification/Actions/src/main/java/com/datalogics/pdfl/samples/Actions.java
@@ -18,7 +18,7 @@ import com.datalogics.PDFL.ViewDestination;
  * An action is added to the rectangle in the form of a hyperlink; if the viewer
  * clicks on the rectangle, it opens a Datalogics web page.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/AddCollection/pom.xml
+++ b/ContentModification/AddCollection/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddCollection</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/AddCollection/src/main/java/com/datalogics/pdfl/samples/AddCollection.java
+++ b/ContentModification/AddCollection/src/main/java/com/datalogics/pdfl/samples/AddCollection.java
@@ -28,7 +28,7 @@ import com.datalogics.PDFL.Collection;
  * 
  * A PDF Portfolio can hold and display multiple additional files as attachments.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/AddQRCode/pom.xml
+++ b/ContentModification/AddQRCode/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddQRCode</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/AddQRCode/src/main/java/com/datalogics/pdfl/samples/AddQRCode.java
+++ b/ContentModification/AddQRCode/src/main/java/com/datalogics/pdfl/samples/AddQRCode.java
@@ -14,7 +14,7 @@ import com.datalogics.PDFL.SaveFlags;
  *
  * This sample shows how to add a QR barcode to a PDF page
  *
- * Copyright (c) 2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2024-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/ChangeLayerConfiguration/pom.xml
+++ b/ContentModification/ChangeLayerConfiguration/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ChangeLayerConfiguration</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/ChangeLayerConfiguration/src/main/java/com/datalogics/pdfl/samples/ChangeLayerConfiguration.java
+++ b/ContentModification/ChangeLayerConfiguration/src/main/java/com/datalogics/pdfl/samples/ChangeLayerConfiguration.java
@@ -7,7 +7,7 @@
  * The sample changes the states of the layers in the document called Layers.pdf and
  * saves the result to a new PDF document.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/ContentModification/ChangeLinkColors/pom.xml
+++ b/ContentModification/ChangeLinkColors/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ChangeLinkColors</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/ChangeLinkColors/src/main/java/com/datalogics/pdfl/samples/ChangeLinkColors.java
+++ b/ContentModification/ChangeLinkColors/src/main/java/com/datalogics/pdfl/samples/ChangeLinkColors.java
@@ -13,7 +13,7 @@ import com.datalogics.PDFL.*;
  * rectangles, and then finds the text that lines up within these rectangles and changes the
  * color of each character that is a part of the hyperlink.  
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class ChangeLinkColors {

--- a/ContentModification/CreateLayer/pom.xml
+++ b/ContentModification/CreateLayer/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>CreateLayer</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/CreateLayer/src/main/java/com/datalogics/pdfl/samples/CreateLayer.java
+++ b/ContentModification/CreateLayer/src/main/java/com/datalogics/pdfl/samples/CreateLayer.java
@@ -7,7 +7,7 @@
  * You can toggle back and forth to make a layer visible or invisible
  * in a PDF Viewer.
  *
- * Copyright (c) 2007-2025, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/ExtendedGraphicStates/pom.xml
+++ b/ContentModification/ExtendedGraphicStates/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ExtendedGraphicStates</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/ExtendedGraphicStates/src/main/java/com/datalogics/pdfl/samples/ExtendedGraphicStates.java
+++ b/ContentModification/ExtendedGraphicStates/src/main/java/com/datalogics/pdfl/samples/ExtendedGraphicStates.java
@@ -9,7 +9,7 @@ package com.datalogics.pdfl.samples;
  * 
  * This sample program shows how to use the Extended Graphic State object to add graphics parameters to an image.
  * 
- * Copyright (c) 2007-2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.BlendMode;

--- a/ContentModification/FlattenTransparency/pom.xml
+++ b/ContentModification/FlattenTransparency/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>FlattenTransparency</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/FlattenTransparency/src/main/java/com/datalogics/pdfl/samples/FlattenTransparency.java
+++ b/ContentModification/FlattenTransparency/src/main/java/com/datalogics/pdfl/samples/FlattenTransparency.java
@@ -18,7 +18,7 @@ import com.datalogics.PDFL.FlattenTransparencyParams;
  * appears on the page. The process to flatten a set of transparencies merges them
  * into a single image on the page.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/LaunchActions/pom.xml
+++ b/ContentModification/LaunchActions/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>LaunchActions</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/LaunchActions/src/main/java/com/datalogics/pdfl/samples/LaunchActions.java
+++ b/ContentModification/LaunchActions/src/main/java/com/datalogics/pdfl/samples/LaunchActions.java
@@ -17,7 +17,7 @@ import com.datalogics.PDFL.LaunchAction;
  * An action is added to the rectangle in the form of a hyperlink; if the reader clicks
  * on the rectangle, a different PDF file opens, showing an image.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/MergePDF/pom.xml
+++ b/ContentModification/MergePDF/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MergePDF</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/MergePDF/src/main/java/com/datalogics/pdfl/samples/MergePDF.java
+++ b/ContentModification/MergePDF/src/main/java/com/datalogics/pdfl/samples/MergePDF.java
@@ -13,7 +13,7 @@ import com.datalogics.PDFL.*;
  * takes the content from the second PDF input document and inserts it in the first
  * input document, and saves the result to the output PDF document.
  *
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class MergePDF {

--- a/ContentModification/PDFObject/pom.xml
+++ b/ContentModification/PDFObject/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PDFObject</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/PDFObject/src/main/java/com/datalogics/pdfl/samples/PDFObject.java
+++ b/ContentModification/PDFObject/src/main/java/com/datalogics/pdfl/samples/PDFObject.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.Page;
  * This sample demonstrates working with data objects in a PDF document. It examines the Objects and displays
  * information about them.  The sample extracts the dictionary for an object called URIAction and updates it using PDFObjects.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class PDFObject {

--- a/ContentModification/PageLabels/pom.xml
+++ b/ContentModification/PageLabels/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PageLabels</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/PageLabels/src/main/java/com/datalogics/pdfl/samples/PageLabels.java
+++ b/ContentModification/PageLabels/src/main/java/com/datalogics/pdfl/samples/PageLabels.java
@@ -11,7 +11,7 @@ import com.datalogics.PDFL.NumberStyle;
  * This sample demonstrates working with page labels in a PDF document. Each PDF file has a 
  * data structure that governs how page numbers appear, such as the font and type of numeral.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/UnderlinesAndHighlights/pom.xml
+++ b/ContentModification/UnderlinesAndHighlights/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>UnderlinesAndHighlights</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/UnderlinesAndHighlights/src/main/java/com/datalogics/pdfl/samples/UnderlinesAndHighlights.java
+++ b/ContentModification/UnderlinesAndHighlights/src/main/java/com/datalogics/pdfl/samples/UnderlinesAndHighlights.java
@@ -26,7 +26,7 @@ import com.datalogics.PDFL.WordFinderVersion;
  * a National Weather Service web page, highlighting the word "Cloudy" wherever it appears and underlining
  * the word "Rain."
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class UnderlinesAndHighlights {

--- a/ContentModification/Watermark/pom.xml
+++ b/ContentModification/Watermark/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>Watermark</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/ContentModification/Watermark/src/main/java/com/datalogics/pdfl/samples/Watermark.java
+++ b/ContentModification/Watermark/src/main/java/com/datalogics/pdfl/samples/Watermark.java
@@ -14,7 +14,7 @@ import com.datalogics.PDFL.*;
  * a set of photographs shown in a PDF file so that they cannot be easily duplicated without
  * the permission of the owner.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/pom.xml
+++ b/Display/DisplayPDF/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>DisplayPDF</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/DisplayPDF.java
+++ b/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/DisplayPDF.java
@@ -4,7 +4,7 @@ package com.datalogics.pdfl.samples;
  * This sample shows how to open a PDF document, search for text in the pages and highlight
  * the text. This utility is a simpler version of the JavaViewer sample.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerFrame.java
+++ b/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerFrame.java
@@ -2,7 +2,7 @@
  * ViewerFrame.java
  *
  *
- * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved. 
+ * Copyright (c) 2017-2026, Datalogics, Inc. All rights reserved. 
  *
  */
 

--- a/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerSample.java
+++ b/Display/DisplayPDF/src/main/java/com/datalogics/pdfl/samples/ViewerSample.java
@@ -5,7 +5,7 @@ package com.datalogics.pdfl.samples;
  * A sample which demonstrates the use of the API to view a PDF
  * file and search for text in the file and highlight them.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import javax.swing.*;

--- a/Display/ImageDisplay/pom.xml
+++ b/Display/ImageDisplay/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageDisplay</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplay.java
+++ b/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplay.java
@@ -6,7 +6,7 @@ package com.datalogics.pdfl.samples;
  * in a special window on your computer. The program defines an optional input document to display.
  * The entire first page is converted to a graphic.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayFrame.java
+++ b/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayFrame.java
@@ -1,7 +1,7 @@
 /*
  * ImageDisplayFrame.java
  *
- * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2017-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayer.java
+++ b/Display/ImageDisplay/src/main/java/com/datalogics/pdfl/samples/ImageDisplayer.java
@@ -1,7 +1,7 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2017-2026, Datalogics, Inc. All rights reserved. 
 
  */
 

--- a/Display/JavaViewer/pom.xml
+++ b/Display/JavaViewer/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>JavaViewer</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/ActionProperties.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/ActionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationConsts.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationConsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationFactory.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListenerBroadcaster.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationListenerBroadcaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationProperties.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/AnnotationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/BaseAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/BaseAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/FreeTextAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/FreeTextAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/GroupAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/GroupAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/InkAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/InkAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LineAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LineAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LinkAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/LinkAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolyAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolyAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolygonAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolygonAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolylineAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/PolylineAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/RectangularAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/RectangularAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/TextMarkupAnnotationHolder.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Annotations/TextMarkupAnnotationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AppendCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AppendCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AutosizeVerticallyCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/AutosizeVerticallyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseAnnotationCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseGroupCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/BaseGroupCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeAnnotationColorCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeAnnotationColorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeArrowHeadCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeArrowHeadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeDashPatternCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeDashPatternCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontAlignmentCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontAlignmentCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontFaceCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontFaceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontSizeCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeFontSizeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeLineWidthCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ChangeLineWidthCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CloseCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CloseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandStack.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandType.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CommandType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CreateAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CreateAnnotationCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CustomEditCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/CustomEditCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteAnnotationCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteGroupCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DeleteGroupCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DocumentCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/DocumentCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditAnnotationCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditAnnotationCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditGroupCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/EditGroupCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/GoToCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/GoToCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/LayersCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/LayersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/MarqueeZoomCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/MarqueeZoomCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/NavigateCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/NavigateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/OpenCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/OpenCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PendingCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PendingCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PrintCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/PrintCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/SaveCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/SaveCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ScrollCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ScrollCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ShowBorderCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ShowBorderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UnlockCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UnlockCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UpdatePropertyCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/UpdatePropertyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewModeCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ViewModeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ZoomCommand.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Command/ZoomCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Constants.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/DocumentListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/DocumentListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/JavaDocument.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Document/JavaDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/DropDownButtonModel.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/DropDownButtonModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/JavaViewer.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/JavaViewer.java
@@ -1,7 +1,7 @@
 /*
  * This sample is a utility that demonstrates a PDF viewing tool. You can use it to open, display, and edit PDF files.
  * 
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/MenuButton.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/MenuButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Application.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/ApplicationController.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/ApplicationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/BookmarksPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/BookmarksPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/DocumentCache.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/DocumentCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageCache.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageModel.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Cache/PageModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ApplicationMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ApplicationMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/DialogMenuItem.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/DialogMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/MenuType.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/MenuType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/NavigateMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/NavigateMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/PageViewMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/PageViewMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ZoomMode.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Enums/ZoomMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/BaseInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/BaseInteractive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditAnnotationInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditAnnotationInteractive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorStates.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/EditorStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/AnnotationEditorFactory.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/AnnotationEditorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/BaseAnnotationOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CircleAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CircleAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateCustomEditAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateCustomEditAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateInkAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateInkAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateLineAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateLineAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreatePolyAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreatePolyAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateRectangularAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateRectangularAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/CreateTextMarkupOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationOuptut.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/EditAnnotationOuptut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/FreeTextAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/FreeTextAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GroupAnnotationOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GuideRectangle.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/GuideRectangle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/Hit.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/Hit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/HoverAnnotationOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/InkAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/InkAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LineAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LineAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetOutput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/LinkTargetOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyLineAnnoationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolyLineAnnoationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolygonAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/PolygonAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectAnnotationInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectAnnotationInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectGroupInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SelectGroupInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SquareAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/SquareAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextEditInput.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextEditInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextMarkupAnnotationEditor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Editors/TextMarkupAnnotationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Interactive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/Interactive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/LinkTargetInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/LinkTargetInteractive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/MarqueeZoomInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/MarqueeZoomInteractive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ScrollModeInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ScrollModeInteractive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ZoomModeInteractive.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/Interactive/ZoomModeInteractive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/KeyNavigationPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/KeyNavigationPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  */
 
 package com.datalogics.pdfl.JavaViewer.Presentation;

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/LayersPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/LayersPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/PDFPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/PDFPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/TextSearchPresenter.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Presentation/TextSearchPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Utils.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AnnotationPropertyAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AnnotationPropertyAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AppendAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AppendAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ApplicationModeAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ApplicationModeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AutosizeVerticallyAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AutosizeVerticallyAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AvailableActions.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/AvailableActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeAnnotationColor.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeAnnotationColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeArrowHead.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeArrowHead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeDashPatternAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeDashPatternAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeLineWidthAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ChangeLineWidthAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CloseAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CloseAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CreateAnnotationAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/CreateAnnotationAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DeleteAnnotationAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DeleteAnnotationAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DialogMenuAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/DialogMenuAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontAlignmentChangedAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontAlignmentChangedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontFaceChangedAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontFaceChangedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontSizeChangedAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/FontSizeChangedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/MonitorResolutionAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/MonitorResolutionAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/NavigateAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/NavigateAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/OpenAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/OpenAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/PrintAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/PrintAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/RedoAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/RedoAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SaveAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SaveAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ShowBorderAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ShowBorderAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SimpleAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/SimpleAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/TextSearchAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/TextSearchAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UndoAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UndoAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UnlockAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/UnlockAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ViewModeAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ViewModeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ZoomAction.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Actions/ZoomAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/BookmarksView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/BookmarksView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ColorPickerIcon.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ColorPickerIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/DialogsView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/DialogsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/InputDataView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/InputDataView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Bookmarks.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Bookmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/ColorPicker.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/ColorPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/DialogMenuResultNotifier.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/DialogMenuResultNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Dialogs.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Dialogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/InputData.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/InputData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Layers.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Layers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/LinkTargetDialog.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/LinkTargetDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PDF.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PropertyDialog.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/PropertyDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/TextEdit.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/TextEdit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Viewer.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/Interfaces/Viewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/JavaViewerComponent.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/JavaViewerComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/LayersView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/LayersView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/MessageDialogType.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/MessageDialogType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/PDFView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/PDFView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ScrollingView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/ScrollingView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/SelectionListener.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/SelectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/TextEditView.java
+++ b/Display/JavaViewer/src/main/java/com/datalogics/pdfl/JavaViewer/Views/TextEditView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (C) 2011-2026, Datalogics, Inc. All rights reserved.
  * 
  */
 

--- a/Display/PDFObjectExplorer/pom.xml
+++ b/Display/PDFObjectExplorer/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PDFObjectExplorer</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/EnumObjectsForTree.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/EnumObjectsForTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2026, Datalogics, Inc. All rights reserved.
  *
  *
  * ========================== Enum Objects For Tree ===========================

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilenameFilter.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilenameFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2026, Datalogics, Inc. All rights reserved.
  *
  *
  * ============================ PDFFilenameFilter ===================================

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilter.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2026, Datalogics, Inc. All rights reserved.
  *
  * ============================ PDFFilter ===================================
  * This filter is used with the file chooser to limit displayed files to those

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFNode.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2026, Datalogics, Inc. All rights reserved.
  *
  *
  * =============================== PDF NODE ===================================

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectExplorer.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectExplorer.java
@@ -4,7 +4,7 @@
  * information about objects embedded in a PDF file. These objects include arrays, dictionaries,
  * streams of characters, and integers.
  *
- * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2026, Datalogics, Inc. All rights reserved.
  *
  */
 package com.datalogics.pdfl.samples;

--- a/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectTreeIconRenderer.java
+++ b/Display/PDFObjectExplorer/src/main/java/com/datalogics/pdfl/samples/PDFObjectTreeIconRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2009-2026, Datalogics, Inc. All rights reserved.
  *
  *
  * ===================== PDF Object Tree Icon Renderer ========================

--- a/DocumentConversion/ColorConvertDocument/pom.xml
+++ b/DocumentConversion/ColorConvertDocument/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ColorConvertDocument</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/ColorConvertDocument/src/main/java/com/datalogics/pdfl/samples/ColorConvertDocument.java
+++ b/DocumentConversion/ColorConvertDocument/src/main/java/com/datalogics/pdfl/samples/ColorConvertDocument.java
@@ -26,7 +26,7 @@ import com.datalogics.PDFL.ColorConvertParams;
  * Note that the color profile is not embedded by default; rather, the default is not to embed the color profile.
  * The user must set the option to embed to True.
  * 
- * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2017-2026, Datalogics, Inc. All rights reserved.
  *
  */
  

--- a/DocumentConversion/ConvertToOffice/pom.xml
+++ b/DocumentConversion/ConvertToOffice/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ConvertToOffice</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -39,32 +39,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/ConvertToOffice/src/main/java/com/datalogics/pdfl/samples/ConvertToOffice.java
+++ b/DocumentConversion/ConvertToOffice/src/main/java/com/datalogics/pdfl/samples/ConvertToOffice.java
@@ -9,7 +9,7 @@ import com.datalogics.PDFL.Library;
  *
  * ConvertToOffice converts sample PDF documents to Office Documents.
  *
- * Copyright (c) 2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2023-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class ConvertToOffice

--- a/DocumentConversion/CreateDocFromXPS/pom.xml
+++ b/DocumentConversion/CreateDocFromXPS/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>CreateDocFromXPS</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -39,32 +39,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/CreateDocFromXPS/src/main/java/com/datalogics/pdfl/samples/CreateDocFromXPS.java
+++ b/DocumentConversion/CreateDocFromXPS/src/main/java/com/datalogics/pdfl/samples/CreateDocFromXPS.java
@@ -13,7 +13,7 @@ import com.datalogics.PDFL.XPSConvertParams;
  * XML Paper Specification (XPS) is a standard document format that Microsoft created in 2006
  * as an alternative to the PDF format.  
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/DocumentConversion/FacturXConverter/pom.xml
+++ b/DocumentConversion/FacturXConverter/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>FacturXConverter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/FacturXConverter/src/main/java/com/datalogics/pdfl/samples/FacturXConverter.java
+++ b/DocumentConversion/FacturXConverter/src/main/java/com/datalogics/pdfl/samples/FacturXConverter.java
@@ -19,7 +19,7 @@ import com.datalogics.PDFL.PDFName;
  *
  * This sample demonstrates converting the input PDF with the input Invoice XML to a Factur-X compliant PDF.
  *
- * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2022-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class FacturXConverter

--- a/DocumentConversion/PDFAConverter/pom.xml
+++ b/DocumentConversion/PDFAConverter/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PDFAConverter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/PDFAConverter/src/main/java/com/datalogics/pdfl/samples/PDFAConverter.java
+++ b/DocumentConversion/PDFAConverter/src/main/java/com/datalogics/pdfl/samples/PDFAConverter.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.PDFAConvertResult;
  * This sample demonstrates converting a standard PDF document into a
  * PDF Archive, or PDF/A, compliant version of a PDF file.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class PDFAConverter

--- a/DocumentConversion/PDFXConverter/pom.xml
+++ b/DocumentConversion/PDFXConverter/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PDFXConverter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/PDFXConverter/src/main/java/com/datalogics/pdfl/samples/PDFXConverter.java
+++ b/DocumentConversion/PDFXConverter/src/main/java/com/datalogics/pdfl/samples/PDFXConverter.java
@@ -15,7 +15,7 @@ import com.datalogics.PDFL.PDFXConvertResult;
  * 
  * The sample takes a default input and output a document (both optional). 
  * 
- * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2017-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class PDFXConverter

--- a/DocumentConversion/ZUGFeRDConverter/pom.xml
+++ b/DocumentConversion/ZUGFeRDConverter/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ZUGFeRDConverter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentConversion/ZUGFeRDConverter/src/main/java/com/datalogics/pdfl/samples/ZUGFeRDConverter.java
+++ b/DocumentConversion/ZUGFeRDConverter/src/main/java/com/datalogics/pdfl/samples/ZUGFeRDConverter.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.PDFAConvertResult;
  *
  * This sample demonstrates converting the input PDF with the input Invoice ZUGFeRD XML to a ZUGFeRD compliant PDF.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class ZUGFeRDConverter

--- a/DocumentOptimization/PDFOptimize/pom.xml
+++ b/DocumentOptimization/PDFOptimize/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PDFOptimize</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/DocumentOptimization/PDFOptimize/src/main/java/com/datalogics/pdfl/samples/PDFOptimize.java
+++ b/DocumentOptimization/PDFOptimize/src/main/java/com/datalogics/pdfl/samples/PDFOptimize.java
@@ -17,7 +17,7 @@ import com.datalogics.PDFL.*;
  * to suit your applications needs and drop such content to achieve better compression if you already
  * know it's unnecessary.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Forms/ConvertXFAToAcroForms/pom.xml
+++ b/Forms/ConvertXFAToAcroForms/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ConvertXFAToAcroForms</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -39,56 +39,56 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Forms/ConvertXFAToAcroForms/src/main/java/com/datalogics/pdfl/samples/ConvertXFAToAcroForms.java
+++ b/Forms/ConvertXFAToAcroForms/src/main/java/com/datalogics/pdfl/samples/ConvertXFAToAcroForms.java
@@ -3,7 +3,7 @@ package com.datalogics.pdfl.samples;
 /*
  * Converts XFA (Dynamic or Static) fields to AcroForms fields and removes XFA fields.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  */
 import com.datalogics.PDFL.*;
 import java.util.EnumSet;

--- a/Forms/ExportFormsData/pom.xml
+++ b/Forms/ExportFormsData/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ExportFormsData</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -39,56 +39,56 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Forms/FlattenForms/pom.xml
+++ b/Forms/FlattenForms/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>FlattenForms</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -39,56 +39,56 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Forms/FlattenForms/src/main/java/com/datalogics/pdfl/samples/FlattenForms.java
+++ b/Forms/FlattenForms/src/main/java/com/datalogics/pdfl/samples/FlattenForms.java
@@ -8,7 +8,7 @@ package com.datalogics.pdfl.samples;
  *  - Flatten XFA (Dynamic or Static) to regular page content which converts and expands XFA fields to regular PDF content and removes the XFA fields.
  *  - Flatten AcroForms to regular page content which converts AcroForm fields to regular page content and removes the AcroForm fields.
  *
- * Copyright (c) 2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2024-2026, Datalogics, Inc. All rights reserved.
  */
 import com.datalogics.PDFL.*;
 import java.util.EnumSet;

--- a/Forms/ImportFormsData/pom.xml
+++ b/Forms/ImportFormsData/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImportFormsData</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -39,56 +39,56 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>forms-extension</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Forms/ImportFormsData/src/main/java/com/datalogics/pdfl/samples/ImportFormsData.java
+++ b/Forms/ImportFormsData/src/main/java/com/datalogics/pdfl/samples/ImportFormsData.java
@@ -8,7 +8,7 @@ package com.datalogics.pdfl.samples;
  *  - Import data into a XFA (Dynamic or Static) document, the types supported include XDP, XML, or XFD
  *  - Import data into an AcroForms document, the types supported include XFDF, FDF, or XML
  *
- * Copyright (c) 2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2024-2026, Datalogics, Inc. All rights reserved.
 
  */
 import com.datalogics.PDFL.*;

--- a/Forms/README.md
+++ b/Forms/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://docs.datalogics.com/apdfl18/Java/) &nbsp; | &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
+[Documentation](https://docs.datalogics.com/apdfl21/Java/) &nbsp; | &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
 [![Download a Free Trial](https://img.shields.io/badge/maven%20package-APDFL%20Free%20Trial-blue?style=plastic&logo=apachemaven)](https://central.sonatype.com/artifact/com.datalogics.pdfl/forms-extension)
 

--- a/Forms/README.md
+++ b/Forms/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://docs.datalogics.com/apdfl21/Java/) &nbsp; | &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
+[Documentation](https://docs.datalogics.com/apdfl21/Java/) &nbsp; | &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
 [![Download a Free Trial](https://img.shields.io/badge/maven%20package-APDFL%20Free%20Trial-blue?style=plastic&logo=apachemaven)](https://central.sonatype.com/artifact/com.datalogics.pdfl/forms-extension)
 

--- a/Images/DocToImages/pom.xml
+++ b/Images/DocToImages/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>DocToImages</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/DocToImages/src/main/java/com/datalogics/pdfl/samples/DocToImages.java
+++ b/Images/DocToImages/src/main/java/com/datalogics/pdfl/samples/DocToImages.java
@@ -6,7 +6,7 @@ package com.datalogics.pdfl.samples;
  * one per page. You can also create a multi-page TIFF file. This program requires that you enter 
  * formatting values manually at the command line. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/DrawSeparations/pom.xml
+++ b/Images/DrawSeparations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>DrawSeparations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/EPSSeparations/pom.xml
+++ b/Images/EPSSeparations/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>EPSSeparations</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/EPSSeparations/src/main/java/com/datalogics/pdfl/samples/EPSSeparations.java
+++ b/Images/EPSSeparations/src/main/java/com/datalogics/pdfl/samples/EPSSeparations.java
@@ -9,7 +9,7 @@ import com.datalogics.PDFL.*;
  * This sample demonstrates working with color separations with Encapsulated PostScript (EPS) graphics
  * from a PDF file.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/GetSeparatedImages/pom.xml
+++ b/Images/GetSeparatedImages/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>GetSeparatedImages</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/GetSeparatedImages/src/main/java/com/datalogics/pdfl/samples/GetSeparatedImages.java
+++ b/Images/GetSeparatedImages/src/main/java/com/datalogics/pdfl/samples/GetSeparatedImages.java
@@ -17,7 +17,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
 /*
  * This sample demonstrates drawing a list of grayscale separations from a PDF file to multi-paged TIFF file.
  *
- * Copyright (c) 2007-2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class GetSeparatedImages {

--- a/Images/ImageDisplayByteArray/pom.xml
+++ b/Images/ImageDisplayByteArray/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageDisplayByteArray</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArray.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArray.java
@@ -14,7 +14,7 @@ package com.datalogics.pdfl.samples;
  * ImageDisplayByteArray takes the content for the first page of a PDF file and stores it
  * in a Byte Array, and then exports that content from the Byte Array to the display viewer.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  *
  */

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayDisplay.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayDisplay.java
@@ -1,7 +1,7 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved. 
 
  */
 import java.awt.*;

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayFrame.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/ImageDisplayByteArrayFrame.java
@@ -1,7 +1,7 @@
 /*
  * ImageDisplayByateArrayFrame.java
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved. 
  *
  *
  */

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDCancelProc.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDCancelProc.java
@@ -1,7 +1,7 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved. 
  */
 import java.awt.*;
 import java.awt.Point;

--- a/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDRenderProgressProc.java
+++ b/Images/ImageDisplayByteArray/src/main/java/com/datalogics/pdfl/samples/PGDRenderProgressProc.java
@@ -1,7 +1,7 @@
 package com.datalogics.pdfl.samples;
 
 /*
-Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved. 
 
  */
 

--- a/Images/ImageEmbedICCProfile/pom.xml
+++ b/Images/ImageEmbedICCProfile/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageEmbedICCProfile</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ExportDocImage.java
+++ b/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ExportDocImage.java
@@ -13,7 +13,7 @@ import com.datalogics.PDFL.PageImageParams;
 import com.datalogics.PDFL.RenderIntent;
 
 /*
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class ExportDocImage {

--- a/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ImageEmbedICCProfile.java
+++ b/Images/ImageEmbedICCProfile/src/main/java/com/datalogics/pdfl/samples/ImageEmbedICCProfile.java
@@ -15,7 +15,7 @@ import com.datalogics.PDFL.PDFStream;
  * The program sets up how the output will be rendered and generates a TIF image file or
  * series of TIF files as output.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExport/pom.xml
+++ b/Images/ImageExport/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageExport</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ExportDocumentImages.java
+++ b/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ExportDocumentImages.java
@@ -3,7 +3,7 @@ package com.datalogics.pdfl.samples;
 import com.datalogics.PDFL.*;
 
 /*
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ImageExport.java
+++ b/Images/ImageExport/src/main/java/com/datalogics/pdfl/samples/ImageExport.java
@@ -11,7 +11,7 @@ package com.datalogics.pdfl.samples;
  * sets of graphics files for those three images. The sample program ignores text, parsing the
  * PDF syntax to identify any raster or vector images found on every page.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExtraction/pom.xml
+++ b/Images/ImageExtraction/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageExtraction</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageExtraction/src/main/java/com/datalogics/pdfl/samples/ImageExtraction.java
+++ b/Images/ImageExtraction/src/main/java/com/datalogics/pdfl/samples/ImageExtraction.java
@@ -8,7 +8,7 @@ package com.datalogics.pdfl.samples;
  * same directory. Vector images, such as clip art, will not be exported.
  * 
  *
- * Copyright (c) 2007-2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageFromBufferedImage/pom.xml
+++ b/Images/ImageFromBufferedImage/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageFromBufferedImage</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageFromBufferedImage/src/main/java/com/datalogics/pdfl/samples/ImageFromBufferedImage.java
+++ b/Images/ImageFromBufferedImage/src/main/java/com/datalogics/pdfl/samples/ImageFromBufferedImage.java
@@ -20,7 +20,7 @@ import com.datalogics.PDFL.SaveFlags;
  * This sample shows how to create an image object in a PDF document by drawing a graphic from 
  * memory, rather than from another PDF document.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageFromByteArray/pom.xml
+++ b/Images/ImageFromByteArray/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageFromByteArray</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageFromByteArray/src/main/java/com/datalogics/pdfl/samples/ImageFromByteArray.java
+++ b/Images/ImageFromByteArray/src/main/java/com/datalogics/pdfl/samples/ImageFromByteArray.java
@@ -24,7 +24,7 @@ import com.datalogics.PDFL.SaveFlags;
 * 
 * When you run the program it will generate a single PDF as an output file.
 *
-* Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+* Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
 *
 */
 

--- a/Images/ImageImport/pom.xml
+++ b/Images/ImageImport/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageImport</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageImport/src/main/java/com/datalogics/pdfl/samples/ImageImport.java
+++ b/Images/ImageImport/src/main/java/com/datalogics/pdfl/samples/ImageImport.java
@@ -2,7 +2,7 @@
  * 
  * This sample demonstrates how to import an image into a PDF file.
  * 
- * Copyright (c) 2007-2025, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageResampling/pom.xml
+++ b/Images/ImageResampling/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ImageResampling</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/ImageResampling/src/main/java/com/datalogics/pdfl/samples/ImageResampling.java
+++ b/Images/ImageResampling/src/main/java/com/datalogics/pdfl/samples/ImageResampling.java
@@ -10,7 +10,7 @@ package com.datalogics.pdfl.samples;
  * the process makes the PDF document smaller, too.
  *
  *
- * Copyright (c) 2008-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2008-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/OutputPreview/pom.xml
+++ b/Images/OutputPreview/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>OutputPreview</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/OutputPreview/src/main/java/com/datalogics/pdfl/samples/OutputPreview.java
+++ b/Images/OutputPreview/src/main/java/com/datalogics/pdfl/samples/OutputPreview.java
@@ -18,7 +18,7 @@ import com.datalogics.PDFL.SeparationColorSpace;
  * This sample demonstrates creating an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
  *
  * 
- * Copyright (c)2023-2024, Datalogics, Inc. All rights reserved.
+ * Copyright (c)2023-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/RasterizePage/pom.xml
+++ b/Images/RasterizePage/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>RasterizePage</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Images/RasterizePage/src/main/java/com/datalogics/pdfl/samples/RasterizePage.java
+++ b/Images/RasterizePage/src/main/java/com/datalogics/pdfl/samples/RasterizePage.java
@@ -27,7 +27,7 @@ public class RasterizePage {
 	 * 3. An output image file with content drawn from an unrotated PDF page, but that contains only the top half of
 	 *    the original page.
 	 *
-	 * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+	 * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
 	 *
 	 */
 	

--- a/InformationExtraction/ListBookmarks/pom.xml
+++ b/InformationExtraction/ListBookmarks/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ListBookmarks</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListBookmarks/src/main/java/com/datalogics/pdfl/samples/ListBookmarks.java
+++ b/InformationExtraction/ListBookmarks/src/main/java/com/datalogics/pdfl/samples/ListBookmarks.java
@@ -3,7 +3,7 @@ package com.datalogics.pdfl.samples;
 * 
  * This sample finds and describes the bookmarks included in a PDF document.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import java.io.BufferedReader;

--- a/InformationExtraction/ListFonts/pom.xml
+++ b/InformationExtraction/ListFonts/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ListFonts</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListFonts/src/main/java/com/datalogics/pdfl/samples/ListFonts.java
+++ b/InformationExtraction/ListFonts/src/main/java/com/datalogics/pdfl/samples/ListFonts.java
@@ -11,7 +11,7 @@ import java.util.*;
  * The font name appears with the type, such as Type0, Type1, or TrueType, and the encoding method,
  * such as WinAnsiEncoding.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 public class ListFonts {

--- a/InformationExtraction/ListInfo/pom.xml
+++ b/InformationExtraction/ListInfo/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ListInfo</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListInfo/src/main/java/com/datalogics/pdfl/samples/ListInfo.java
+++ b/InformationExtraction/ListInfo/src/main/java/com/datalogics/pdfl/samples/ListInfo.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.*;
  * The results are exported to a PDF output document.
  * 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListLayers/pom.xml
+++ b/InformationExtraction/ListLayers/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ListLayers</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListLayers/src/main/java/com/datalogics/pdfl/samples/ListLayers.java
+++ b/InformationExtraction/ListLayers/src/main/java/com/datalogics/pdfl/samples/ListLayers.java
@@ -6,7 +6,7 @@ package com.datalogics.pdfl.samples;
  *
  * This sample searches for and lists the names of the color layers found in a PDF document. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import java.io.BufferedReader;

--- a/InformationExtraction/ListPaths/pom.xml
+++ b/InformationExtraction/ListPaths/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ListPaths</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/ListPaths/src/main/java/com/datalogics/pdfl/samples/ListPaths.java
+++ b/InformationExtraction/ListPaths/src/main/java/com/datalogics/pdfl/samples/ListPaths.java
@@ -27,7 +27,7 @@ import com.datalogics.PDFL.Segment;
  * Paths in PDF documents, or clipping paths, define the boundaries for art or graphics.
  * 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  */
 public class ListPaths {
 

--- a/InformationExtraction/Metadata/pom.xml
+++ b/InformationExtraction/Metadata/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>Metadata</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/InformationExtraction/Metadata/src/main/java/com/datalogics/pdfl/samples/Metadata.java
+++ b/InformationExtraction/Metadata/src/main/java/com/datalogics/pdfl/samples/Metadata.java
@@ -20,7 +20,7 @@ import org.w3c.dom.NodeList;
  * window of a PDF Viewer. Click File/Properties, and then click Additional Metadata.
  *
  *
- * Copyright (c) 2008-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2008-2026, Datalogics, Inc. All rights reserved.
  *
 ==
  */

--- a/OpticalCharacterRecognition/AddTextToDocument/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToDocument/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddTextToDocument</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,38 +51,38 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/AddTextToDocument/src/main/java/com/datalogics/pdfl/samples/AddTextToDocument.java
+++ b/OpticalCharacterRecognition/AddTextToDocument/src/main/java/com/datalogics/pdfl/samples/AddTextToDocument.java
@@ -24,7 +24,7 @@ import com.datalogics.PDFL.Group;
  * Process a document using the optical character recognition engine.
  * Then place the image and the processed text in an output pdf
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/AddTextToImage/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToImage/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddTextToImage</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,38 +51,38 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/AddTextToImage/src/main/java/com/datalogics/pdfl/samples/AddTextToImage.java
+++ b/OpticalCharacterRecognition/AddTextToImage/src/main/java/com/datalogics/pdfl/samples/AddTextToImage.java
@@ -22,7 +22,7 @@ import com.datalogics.PDFL.SaveFlags;
  * The sample uses an image as input which will be processed by the optical character recognition engine.
  * We will then place the image and the processed text in an output pdf
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/OCRDocument/pom.xml
+++ b/OpticalCharacterRecognition/OCRDocument/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>OCRDocument</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,38 +51,38 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
     </dependency>
   </dependencies>

--- a/OpticalCharacterRecognition/OCRDocument/src/main/java/com/datalogics/pdfl/samples/OCRDocument.java
+++ b/OpticalCharacterRecognition/OCRDocument/src/main/java/com/datalogics/pdfl/samples/OCRDocument.java
@@ -21,7 +21,7 @@ import com.datalogics.PDFL.SaveFlags;
 /*
  * Runs OCR on the document recognizing text found on its rasterized pages.
  * 
- * Copyright (c) 2007-2025, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Other/MemoryFileSystem/pom.xml
+++ b/Other/MemoryFileSystem/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>MemoryFileSystem</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Other/MemoryFileSystem/src/main/java/com/datalogics/pdfl/samples/MemoryFileSystem.java
+++ b/Other/MemoryFileSystem/src/main/java/com/datalogics/pdfl/samples/MemoryFileSystem.java
@@ -19,7 +19,7 @@ import com.datalogics.PDFL.TempStoreType;
  * TempStoreType.Memory. The program can also set a maximum amount of RAM to use by
  * applying a value to the DefaultTempStoreMemLimit property.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Other/StreamIO/pom.xml
+++ b/Other/StreamIO/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>StreamIO</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Other/StreamIO/src/main/java/com/datalogics/pdfl/samples/StreamIO.java
+++ b/Other/StreamIO/src/main/java/com/datalogics/pdfl/samples/StreamIO.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.*;
  * 
  * This program is similar to ImagefromStream, but in this example the PDF file streams hold text.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDF/pom.xml
+++ b/Printing/PrintPDF/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PrintPDF</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintCancelProc.java
+++ b/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintCancelProc.java
@@ -3,7 +3,7 @@ package com.datalogics.pdfl.samples;
  * 
  * A sample which demonstrates the use of a cancel callback in a print job.
  *  
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.PrintCancelProc;

--- a/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintProgressProc.java
+++ b/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PGDPrintProgressProc.java
@@ -4,7 +4,7 @@ package com.datalogics.pdfl.samples;
  * A sample which demonstrates how to obtain information about
  * print job progress.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PrintPDF.java
+++ b/Printing/PrintPDF/src/main/java/com/datalogics/pdfl/samples/PrintPDF.java
@@ -14,7 +14,7 @@ import com.datalogics.PDFL.*;
  * computer in use. This program is useful in that it identifies the API you need to use to
  * print PDF files. It also generates a Postscript (PS) output file. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDFGUI/pom.xml
+++ b/Printing/PrintPDFGUI/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>PrintPDFGUI</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Printing/PrintPDFGUI/src/main/java/com/datalogics/pdfl/samples/PrintPDFGUI.java
+++ b/Printing/PrintPDFGUI/src/main/java/com/datalogics/pdfl/samples/PrintPDFGUI.java
@@ -9,7 +9,7 @@ import com.datalogics.PDFL.*;
  * This sample demonstrates printing a PDF file. It is similar to PrintPDF, but this
  * program provides a user interface.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://dev.datalogics.com/adobe-pdf-library/java/getting-started) &nbsp; | &nbsp; [API Reference](https://docs.datalogics.com/apdfl18/Java/) &nbsp; | &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
+[Documentation](https://dev.datalogics.com/adobe-pdf-library-21/java/getting-started) &nbsp; | &nbsp; [API Reference](https://docs.datalogics.com/apdfl21/Java/) &nbsp; | &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
 
 [![Download a Free Trial](https://img.shields.io/badge/maven%20package-APDFL%20Free%20Trial-blue?style=plastic&logo=apachemaven)](https://central.sonatype.com/artifact/com.datalogics.pdfl/pdfl)
 
 ## Adobe PDF Library
-Built upon Adobe source code used for Acrobat, Datalogics Adobe PDF Library SDK provides stable, reliable code and the flexibility to develop with Java, C#, VB (VB.NET), or C++. APDFL is the most complete SDK for PDF creation, manipulation and management. Best for enterprise/larger organizations of developers and independent software vendors (ISVs) who need to incorporate Adobe's PDF functionality into their own internal or external applications.
+Built upon Adobe source code used for Acrobat, Datalogics Adobe PDF Library SDK provides stable, reliable code and the flexibility to develop with Java, C#, VB (VB.NET), or C++. APDFL is the most complete SDK for PDF creation, manipulation, and management. Best for enterprise/larger organizations of developers and independent software vendors (ISVs) who need to incorporate Adobe's PDF functionality into their own internal or external applications.
 
 Live support from PDF development experts.
 

--- a/Security/AddBasicPAdESElectronicSignature/pom.xml
+++ b/Security/AddBasicPAdESElectronicSignature/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddBasicPAdESElectronicSignature</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/AddDigitalSignatureCMS/pom.xml
+++ b/Security/AddDigitalSignatureCMS/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddDigitalSignatureCMS</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/AddDigitalSignatureCMS/src/main/java/com/datalogics/pdfl/samples/AddDigitalSignatureCMS.java
+++ b/Security/AddDigitalSignatureCMS/src/main/java/com/datalogics/pdfl/samples/AddDigitalSignatureCMS.java
@@ -2,7 +2,7 @@
  *
  * This sample program demonstrates the use of AddDigitalSignature for CMS signature type.
  *
- * Copyright (c) 2025, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2025-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Security/AddDigitalSignatureRFC3161/pom.xml
+++ b/Security/AddDigitalSignatureRFC3161/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddDigitalSignatureRFC3161</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/AddDigitalSignatureRFC3161/src/main/java/com/datalogics/pdfl/samples/AddDigitalSignatureRFC3161.java
+++ b/Security/AddDigitalSignatureRFC3161/src/main/java/com/datalogics/pdfl/samples/AddDigitalSignatureRFC3161.java
@@ -2,7 +2,7 @@
  *
  * This sample program demonstrates the use of AddDigitalSignature for RFC3161/TimeStamp signature type.
  *
- * Copyright (c) 2025, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2025-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Security/AddPAdESPolicySignature/pom.xml
+++ b/Security/AddPAdESPolicySignature/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddPAdESPolicySignature</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/AddRegexRedaction/pom.xml
+++ b/Security/AddRegexRedaction/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddRegexRedaction</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/AddRegexRedaction/src/main/java/com/datalogics/pdfl/samples/AddRegexRedaction.java
+++ b/Security/AddRegexRedaction/src/main/java/com/datalogics/pdfl/samples/AddRegexRedaction.java
@@ -19,7 +19,7 @@ import java.util.List;
  * document that matches a user-supplied regular expression. When the sample finds the text it
  * will redact the phrase from the output document.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Security/Redactions/pom.xml
+++ b/Security/Redactions/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>Redactions</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Security/Redactions/src/main/java/com/datalogics/pdfl/samples/Redactions.java
+++ b/Security/Redactions/src/main/java/com/datalogics/pdfl/samples/Redactions.java
@@ -9,7 +9,7 @@ import com.datalogics.PDFL.*;
  * This sample shows how to redact a PDF document. The program opens an input PDF, searches for
  * specific words using the WordFinder, and then removes these words from the text.
  * 
- * Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2017-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/AddGlyphs/pom.xml
+++ b/Text/AddGlyphs/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddGlyphs</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/AddGlyphs/src/main/java/com/datalogics/pdfl/samples/AddGlyphs.java
+++ b/Text/AddGlyphs/src/main/java/com/datalogics/pdfl/samples/AddGlyphs.java
@@ -25,7 +25,7 @@ import com.datalogics.PDFL.TextState;
  * managing them by individual Glyph ID codes.
  * 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/AddUnicodeText/pom.xml
+++ b/Text/AddUnicodeText/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddUnicodeText</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/AddUnicodeText/src/main/java/com/datalogics/pdfl/samples/AddUnicodeText.java
+++ b/Text/AddUnicodeText/src/main/java/com/datalogics/pdfl/samples/AddUnicodeText.java
@@ -4,7 +4,7 @@ package com.datalogics.pdfl.samples;
   * 
  * This sample program adds six lines of Unicode text to a PDF file, in six different languages.
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.Document;

--- a/Text/AddVerticalText/pom.xml
+++ b/Text/AddVerticalText/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>AddVerticalText</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/AddVerticalText/src/main/java/com/datalogics/pdfl/samples/AddVerticalText.java
+++ b/Text/AddVerticalText/src/main/java/com/datalogics/pdfl/samples/AddVerticalText.java
@@ -10,7 +10,7 @@ package com.datalogics.pdfl.samples;
  * The PDF output file presents multiple columns of vertical text. The characters appear in English as well as
  * Mandarin, Japanese, and Korean.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 import com.datalogics.PDFL.Document;

--- a/Text/ListWords/pom.xml
+++ b/Text/ListWords/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>ListWords</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/ListWords/src/main/java/com/datalogics/pdfl/samples/ListWords.java
+++ b/Text/ListWords/src/main/java/com/datalogics/pdfl/samples/ListWords.java
@@ -10,7 +10,7 @@ import com.datalogics.PDFL.*;
  * 
  * This sample lists the text for the words in a PDF document.
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/RegexExtractText/pom.xml
+++ b/Text/RegexExtractText/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>RegexExtractText</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -56,32 +56,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/RegexExtractText/src/main/java/com/datalogics/pdfl/samples/RegexExtractText.java
+++ b/Text/RegexExtractText/src/main/java/com/datalogics/pdfl/samples/RegexExtractText.java
@@ -24,7 +24,7 @@ import org.json.JSONObject;
  * that matches a user-supplied regular expression. The output is a JSON file that
  * has the match information.
  *
- * Copyright (c) 2021-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2021-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/RegexTextSearch/pom.xml
+++ b/Text/RegexTextSearch/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>RegexTextSearch</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/RegexTextSearch/src/main/java/com/datalogics/pdfl/samples/RegexTextSearch.java
+++ b/Text/RegexTextSearch/src/main/java/com/datalogics/pdfl/samples/RegexTextSearch.java
@@ -18,7 +18,7 @@ import java.util.List;
  * This sample shows how to search a PDF document using regex pattern matching. The program opens an input PDF, searches for
  * words using the DocTextFinder, and then prints these words to the console.
  *
- * Copyright (c) 2021-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2021-2026, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/TextExtract/pom.xml
+++ b/Text/TextExtract/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>TextExtract</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
   <profiles>
     <profile>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>${jni.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <type>zip</type>
       <classifier>resources</classifier>
     </dependency>
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>pdfl</artifactId>
-      <version>LATEST</version>
+      <version>[21.0,22.0)</version>
       <classifier>javadoc</classifier>
     </dependency>
   </dependencies>

--- a/Text/TextExtract/src/main/java/com/datalogics/pdfl/samples/TextExtract.java
+++ b/Text/TextExtract/src/main/java/com/datalogics/pdfl/samples/TextExtract.java
@@ -16,7 +16,7 @@ import com.datalogics.PDFL.*;
  * PDF file is tagged or untagged. Tagging is used to make PDF files accessible
  * to the blind or to people with vision problems. 
  *
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2026, Datalogics, Inc. All rights reserved.
  *
  */
 


### PR DESCRIPTION
Update the samples to build and run against the APDFL 21 Maven packages (maven-builder PR datalogics/maven-builder#91), which target Java 17 and publish under the 21.x version line.

Fulfills JIRA issue [APDFL-6637](https://datalogics-jira.atlassian.net/browse/APDFL-6637)

[APDFL-6637]: https://datalogics-jira.atlassian.net/browse/APDFL-6637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ