### PR TITLE
Use unpack-dependencies so the 21.x version range resolves

### DIFF
--- a/Annotations/Annotations/pom.xml
+++ b/Annotations/Annotations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Annotations/InkAnnotations/pom.xml
+++ b/Annotations/InkAnnotations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Annotations/LinkAnnotations/pom.xml
+++ b/Annotations/LinkAnnotations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Annotations/PolyLineAnnotations/pom.xml
+++ b/Annotations/PolyLineAnnotations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Annotations/PolygonAnnotations/pom.xml
+++ b/Annotations/PolygonAnnotations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/AddElements/pom.xml
+++ b/ContentCreation/AddElements/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/AddHeaderFooter/pom.xml
+++ b/ContentCreation/AddHeaderFooter/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/Clips/pom.xml
+++ b/ContentCreation/Clips/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/CreateBookmarks/pom.xml
+++ b/ContentCreation/CreateBookmarks/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/GradientShade/pom.xml
+++ b/ContentCreation/GradientShade/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithLabColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithLabColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/NameTrees/pom.xml
+++ b/ContentCreation/NameTrees/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/NumberTrees/pom.xml
+++ b/ContentCreation/NumberTrees/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/RemoteGoToActions/pom.xml
+++ b/ContentCreation/RemoteGoToActions/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentCreation/WriteNChannelTiff/pom.xml
+++ b/ContentCreation/WriteNChannelTiff/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/Actions/pom.xml
+++ b/ContentModification/Actions/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/AddCollection/pom.xml
+++ b/ContentModification/AddCollection/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/AddQRCode/pom.xml
+++ b/ContentModification/AddQRCode/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/ChangeLayerConfiguration/pom.xml
+++ b/ContentModification/ChangeLayerConfiguration/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/ChangeLinkColors/pom.xml
+++ b/ContentModification/ChangeLinkColors/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/CreateLayer/pom.xml
+++ b/ContentModification/CreateLayer/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/ExtendedGraphicStates/pom.xml
+++ b/ContentModification/ExtendedGraphicStates/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/FlattenTransparency/pom.xml
+++ b/ContentModification/FlattenTransparency/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/LaunchActions/pom.xml
+++ b/ContentModification/LaunchActions/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/MergePDF/pom.xml
+++ b/ContentModification/MergePDF/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/PDFObject/pom.xml
+++ b/ContentModification/PDFObject/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/PageLabels/pom.xml
+++ b/ContentModification/PageLabels/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/UnderlinesAndHighlights/pom.xml
+++ b/ContentModification/UnderlinesAndHighlights/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/ContentModification/Watermark/pom.xml
+++ b/ContentModification/Watermark/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Display/DisplayPDF/pom.xml
+++ b/Display/DisplayPDF/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Display/ImageDisplay/pom.xml
+++ b/Display/ImageDisplay/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Display/JavaViewer/pom.xml
+++ b/Display/JavaViewer/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Display/PDFObjectExplorer/pom.xml
+++ b/Display/PDFObjectExplorer/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/ColorConvertDocument/pom.xml
+++ b/DocumentConversion/ColorConvertDocument/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/ConvertToOffice/pom.xml
+++ b/DocumentConversion/ConvertToOffice/pom.xml
@@ -87,36 +87,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/CreateDocFromXPS/pom.xml
+++ b/DocumentConversion/CreateDocFromXPS/pom.xml
@@ -87,36 +87,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/FacturXConverter/pom.xml
+++ b/DocumentConversion/FacturXConverter/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/PDFAConverter/pom.xml
+++ b/DocumentConversion/PDFAConverter/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/PDFXConverter/pom.xml
+++ b/DocumentConversion/PDFXConverter/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentConversion/ZUGFeRDConverter/pom.xml
+++ b/DocumentConversion/ZUGFeRDConverter/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/DocumentOptimization/PDFOptimize/pom.xml
+++ b/DocumentOptimization/PDFOptimize/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Forms/ConvertXFAToAcroForms/pom.xml
+++ b/Forms/ConvertXFAToAcroForms/pom.xml
@@ -111,54 +111,42 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-forms-extension</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>forms-extension</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>forms-extension</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Forms/ExportFormsData/pom.xml
+++ b/Forms/ExportFormsData/pom.xml
@@ -111,54 +111,42 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-forms-extension</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>forms-extension</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>forms-extension</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Forms/FlattenForms/pom.xml
+++ b/Forms/FlattenForms/pom.xml
@@ -111,54 +111,42 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-forms-extension</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>forms-extension</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>forms-extension</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Forms/ImportFormsData/pom.xml
+++ b/Forms/ImportFormsData/pom.xml
@@ -111,54 +111,42 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
            <execution>
             <id>unpack-forms-extension</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>forms-extension</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>forms-extension</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/DocToImages/pom.xml
+++ b/Images/DocToImages/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/DrawSeparations/pom.xml
+++ b/Images/DrawSeparations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/EPSSeparations/pom.xml
+++ b/Images/EPSSeparations/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/GetSeparatedImages/pom.xml
+++ b/Images/GetSeparatedImages/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageDisplayByteArray/pom.xml
+++ b/Images/ImageDisplayByteArray/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageEmbedICCProfile/pom.xml
+++ b/Images/ImageEmbedICCProfile/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageExport/pom.xml
+++ b/Images/ImageExport/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageExtraction/pom.xml
+++ b/Images/ImageExtraction/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageFromBufferedImage/pom.xml
+++ b/Images/ImageFromBufferedImage/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageFromByteArray/pom.xml
+++ b/Images/ImageFromByteArray/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageImport/pom.xml
+++ b/Images/ImageImport/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/ImageResampling/pom.xml
+++ b/Images/ImageResampling/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/OutputPreview/pom.xml
+++ b/Images/OutputPreview/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Images/RasterizePage/pom.xml
+++ b/Images/RasterizePage/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/InformationExtraction/ListBookmarks/pom.xml
+++ b/InformationExtraction/ListBookmarks/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/InformationExtraction/ListFonts/pom.xml
+++ b/InformationExtraction/ListFonts/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/InformationExtraction/ListInfo/pom.xml
+++ b/InformationExtraction/ListInfo/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/InformationExtraction/ListLayers/pom.xml
+++ b/InformationExtraction/ListLayers/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/InformationExtraction/ListPaths/pom.xml
+++ b/InformationExtraction/ListPaths/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/InformationExtraction/Metadata/pom.xml
+++ b/InformationExtraction/Metadata/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 def ENV_LOC=[:]
 pipeline {
     parameters {
-        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-samples', 'mac-arm-java-samples', 'linux-java-samples'], description: 'Run on specific platform')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
     }
@@ -29,7 +29,7 @@ pipeline {
                 axes {
                     axis {
                         name 'NODE'
-                        values 'windows-java-samples', 'mac-arm-java-samples', 'linux-java-samples'
+                        values 'windows-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples'
                     }
                 }
                 environment {

--- a/OpticalCharacterRecognition/AddTextToDocument/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToDocument/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>[21.0,22.0)</version>
+      <version>LATEST</version>
       <type>zip</type>
     </dependency>
   </dependencies>
@@ -105,53 +105,41 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-ocr-data</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                   <groupId>com.datalogics.pdfl</groupId>
-                   <artifactId>ocr-data</artifactId>
-                   <type>zip</type>
-                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>ocr-data</includeArtifactIds>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/OpticalCharacterRecognition/AddTextToImage/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToImage/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>[21.0,22.0)</version>
+      <version>LATEST</version>
       <type>zip</type>
     </dependency>
   </dependencies>
@@ -105,53 +105,41 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-ocr-data</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                   <groupId>com.datalogics.pdfl</groupId>
-                   <artifactId>ocr-data</artifactId>
-                   <type>zip</type>
-                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>ocr-data</includeArtifactIds>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/OpticalCharacterRecognition/OCRDocument/pom.xml
+++ b/OpticalCharacterRecognition/OCRDocument/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.datalogics.pdfl</groupId>
       <artifactId>ocr-data</artifactId>
-      <version>[21.0,22.0)</version>
+      <version>LATEST</version>
       <type>zip</type>
     </dependency>
   </dependencies>
@@ -105,53 +105,41 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-ocr-data</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                   <groupId>com.datalogics.pdfl</groupId>
-                   <artifactId>ocr-data</artifactId>
-                   <type>zip</type>
-                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>ocr-data</includeArtifactIds>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Other/MemoryFileSystem/pom.xml
+++ b/Other/MemoryFileSystem/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Other/StreamIO/pom.xml
+++ b/Other/StreamIO/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Printing/PrintPDF/pom.xml
+++ b/Printing/PrintPDF/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Printing/PrintPDFGUI/pom.xml
+++ b/Printing/PrintPDFGUI/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Security/AddBasicPAdESElectronicSignature/pom.xml
+++ b/Security/AddBasicPAdESElectronicSignature/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Security/AddDigitalSignatureCMS/pom.xml
+++ b/Security/AddDigitalSignatureCMS/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Security/AddDigitalSignatureRFC3161/pom.xml
+++ b/Security/AddDigitalSignatureRFC3161/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Security/AddPAdESPolicySignature/pom.xml
+++ b/Security/AddPAdESPolicySignature/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Security/AddRegexRedaction/pom.xml
+++ b/Security/AddRegexRedaction/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Security/Redactions/pom.xml
+++ b/Security/Redactions/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/AddGlyphs/pom.xml
+++ b/Text/AddGlyphs/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/AddUnicodeText/pom.xml
+++ b/Text/AddUnicodeText/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/AddVerticalText/pom.xml
+++ b/Text/AddVerticalText/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/ListWords/pom.xml
+++ b/Text/ListWords/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/RegexExtractText/pom.xml
+++ b/Text/RegexExtractText/pom.xml
@@ -104,36 +104,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/RegexTextSearch/pom.xml
+++ b/Text/RegexTextSearch/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/Text/TextExtract/pom.xml
+++ b/Text/TextExtract/pom.xml
@@ -99,36 +99,28 @@
             <id>unpack-resources</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>resources</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>resources</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
             </configuration>
           </execution>
           <execution>
             <id>unpack-jni</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datalogics.pdfl</groupId>
-                  <artifactId>pdfl</artifactId>
-                  <classifier>${jni.classifier}</classifier>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+              <includeArtifactIds>pdfl</includeArtifactIds>
+              <includeClassifiers>${jni.classifier}</includeClassifiers>
+              <includeTypes>zip</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Problem
The `develop-21` samples build failed in two distinct places:

**1. Dependency resolution** — at `maven-dependency-plugin:unpack (unpack-resources)`:
```
Could not find artifact com.datalogics.pdfl:pdfl:zip:resources:[21.0,22.0) in central
```
The poms pin the range `[21.0,22.0)` but used the `unpack` goal with `<artifactItems>`, which **cannot resolve a version range** (still-open [MDEP-650](https://issues.apache.org/jira/browse/MDEP-650)) — so Maven requests a literal artifact `pdfl-[21.0,22.0)-*.zip` and 404s. Same root cause the v18 line hit.

**2. Run platform** — the Linux samples ran on the `linux-java-samples` label (Rocky 8). APDFL 21's native library (`libcom-datalogics-DL210PDFL.so`) requires `GLIBC_2.32`, which Rocky 8 (glibc 2.28) doesn't provide, so the Run Samples stage failed with `UnsatisfiedLinkError: ... version 'GLIBC_2.32' not found`.

## Fix

**Poms (91 files):** Switch each unpack execution from `unpack` to **`unpack-dependencies`**, which unpacks Maven-core-resolved dependencies (ranges supported). Each execution is explicitly scoped to `com.datalogics.pdfl` group + artifact (`<includeGroupIds>` + `<includeArtifactIds>`), with `<includeClassifiers>` (incl. `${jni.classifier}` for platform selection) + `<includeTypes>zip`.

`ocr-data` is set to `LATEST` (3 OCR poms): it's versioned independently on a `1.x` line, decoupled from the APDFL major, so the `[21.0,22.0)` range matches nothing for it.

**Jenkinsfile:** Point the Linux matrix axis at the new `rocky9-java-samples` label (Rocky 9 nodes, glibc 2.34) instead of `linux-java-samples` (Rocky 8), so the APDFL 21 native libraries load at runtime.

## Files changed
The 91 sample `pom.xml` files and `Jenkinsfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
