### PR TITLE
APDFL-6776: add Windows ARM64 and Linux ARM jni classifiers

### DIFF
--- a/Annotations/Annotations/pom.xml
+++ b/Annotations/Annotations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Annotations/InkAnnotations/pom.xml
+++ b/Annotations/InkAnnotations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Annotations/LinkAnnotations/pom.xml
+++ b/Annotations/LinkAnnotations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Annotations/PolyLineAnnotations/pom.xml
+++ b/Annotations/PolyLineAnnotations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Annotations/PolygonAnnotations/pom.xml
+++ b/Annotations/PolygonAnnotations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/AddElements/pom.xml
+++ b/ContentCreation/AddElements/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/AddHeaderFooter/pom.xml
+++ b/ContentCreation/AddHeaderFooter/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/Clips/pom.xml
+++ b/ContentCreation/Clips/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/CreateBookmarks/pom.xml
+++ b/ContentCreation/CreateBookmarks/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/GradientShade/pom.xml
+++ b/ContentCreation/GradientShade/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithLabColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithLabColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/NameTrees/pom.xml
+++ b/ContentCreation/NameTrees/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/NumberTrees/pom.xml
+++ b/ContentCreation/NumberTrees/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/RemoteGoToActions/pom.xml
+++ b/ContentCreation/RemoteGoToActions/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentCreation/WriteNChannelTiff/pom.xml
+++ b/ContentCreation/WriteNChannelTiff/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/Actions/pom.xml
+++ b/ContentModification/Actions/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/AddCollection/pom.xml
+++ b/ContentModification/AddCollection/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/AddQRCode/pom.xml
+++ b/ContentModification/AddQRCode/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/ChangeLayerConfiguration/pom.xml
+++ b/ContentModification/ChangeLayerConfiguration/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/ChangeLinkColors/pom.xml
+++ b/ContentModification/ChangeLinkColors/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/CreateLayer/pom.xml
+++ b/ContentModification/CreateLayer/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/ExtendedGraphicStates/pom.xml
+++ b/ContentModification/ExtendedGraphicStates/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/FlattenTransparency/pom.xml
+++ b/ContentModification/FlattenTransparency/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/LaunchActions/pom.xml
+++ b/ContentModification/LaunchActions/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/MergePDF/pom.xml
+++ b/ContentModification/MergePDF/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/PDFObject/pom.xml
+++ b/ContentModification/PDFObject/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/PageLabels/pom.xml
+++ b/ContentModification/PageLabels/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/UnderlinesAndHighlights/pom.xml
+++ b/ContentModification/UnderlinesAndHighlights/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/ContentModification/Watermark/pom.xml
+++ b/ContentModification/Watermark/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Display/DisplayPDF/pom.xml
+++ b/Display/DisplayPDF/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Display/ImageDisplay/pom.xml
+++ b/Display/ImageDisplay/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Display/JavaViewer/pom.xml
+++ b/Display/JavaViewer/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Display/PDFObjectExplorer/pom.xml
+++ b/Display/PDFObjectExplorer/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/ColorConvertDocument/pom.xml
+++ b/DocumentConversion/ColorConvertDocument/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/ConvertToOffice/pom.xml
+++ b/DocumentConversion/ConvertToOffice/pom.xml
@@ -34,6 +34,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/CreateDocFromXPS/pom.xml
+++ b/DocumentConversion/CreateDocFromXPS/pom.xml
@@ -34,6 +34,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/FacturXConverter/pom.xml
+++ b/DocumentConversion/FacturXConverter/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/PDFAConverter/pom.xml
+++ b/DocumentConversion/PDFAConverter/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/PDFXConverter/pom.xml
+++ b/DocumentConversion/PDFXConverter/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentConversion/ZUGFeRDConverter/pom.xml
+++ b/DocumentConversion/ZUGFeRDConverter/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/DocumentOptimization/PDFOptimize/pom.xml
+++ b/DocumentOptimization/PDFOptimize/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Forms/ConvertXFAToAcroForms/pom.xml
+++ b/Forms/ConvertXFAToAcroForms/pom.xml
@@ -34,6 +34,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Forms/ExportFormsData/pom.xml
+++ b/Forms/ExportFormsData/pom.xml
@@ -34,6 +34,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Forms/FlattenForms/pom.xml
+++ b/Forms/FlattenForms/pom.xml
@@ -34,6 +34,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Forms/ImportFormsData/pom.xml
+++ b/Forms/ImportFormsData/pom.xml
@@ -34,6 +34,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/DocToImages/pom.xml
+++ b/Images/DocToImages/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/DrawSeparations/pom.xml
+++ b/Images/DrawSeparations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/EPSSeparations/pom.xml
+++ b/Images/EPSSeparations/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/GetSeparatedImages/pom.xml
+++ b/Images/GetSeparatedImages/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageDisplayByteArray/pom.xml
+++ b/Images/ImageDisplayByteArray/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageEmbedICCProfile/pom.xml
+++ b/Images/ImageEmbedICCProfile/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageExport/pom.xml
+++ b/Images/ImageExport/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageExtraction/pom.xml
+++ b/Images/ImageExtraction/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageFromBufferedImage/pom.xml
+++ b/Images/ImageFromBufferedImage/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageFromByteArray/pom.xml
+++ b/Images/ImageFromByteArray/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageImport/pom.xml
+++ b/Images/ImageImport/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/ImageResampling/pom.xml
+++ b/Images/ImageResampling/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/OutputPreview/pom.xml
+++ b/Images/OutputPreview/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Images/RasterizePage/pom.xml
+++ b/Images/RasterizePage/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/InformationExtraction/ListBookmarks/pom.xml
+++ b/InformationExtraction/ListBookmarks/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/InformationExtraction/ListFonts/pom.xml
+++ b/InformationExtraction/ListFonts/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/InformationExtraction/ListInfo/pom.xml
+++ b/InformationExtraction/ListInfo/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/InformationExtraction/ListLayers/pom.xml
+++ b/InformationExtraction/ListLayers/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/InformationExtraction/ListPaths/pom.xml
+++ b/InformationExtraction/ListPaths/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/InformationExtraction/Metadata/pom.xml
+++ b/InformationExtraction/Metadata/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,14 +86,16 @@ pipeline {
                                         returnStdout: true
                                     ).trim()
                                 } else {
-                                    // Using the mkenv.py script like this assumes the Python Launcher is
-                                    // installed on the Windows host.
-                                    // https://docs.python.org/3/using/windows.html#launcher
-                                    bat '.\\mkenv.py --verbose'
+                                    // Invoke through the Python Launcher (py) explicitly rather than
+                                    // relying on the .py file association, which on some Windows hosts
+                                    // does not forward arguments (%*). Without the argument, mkenv.py
+                                    // runs a full environment setup and prints pip output, corrupting
+                                    // the value captured below.
+                                    bat 'py mkenv.py --verbose'
                                     ENV_LOC[NODE] = bat (
                                         // The @ prevents Windows from echoing the command itself into the stdout,
                                         // which would corrupt the value of the returned data.
-                                        script: '@.\\mkenv.py --env-name',
+                                        script: '@py mkenv.py --env-name',
                                         returnStdout: true
                                     ).trim()
                                 }
@@ -104,14 +106,16 @@ pipeline {
                         steps {
                             echo "Clean ${NODE}"
                             script {
-                                if (isUnix()) {
-                                    sh """. ${ENV_LOC[NODE]}/bin/activate
-                                          invoke clean-samples
-                                    """
-                                } else {
-                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                          invoke clean-samples
-                                    """
+                                configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+                                    if (isUnix()) {
+                                        sh """. ${ENV_LOC[NODE]}/bin/activate
+                                              invoke clean-samples
+                                        """
+                                    } else {
+                                        bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                              invoke clean-samples
+                                        """
+                                    }
                                 }
                             }
                         }
@@ -120,14 +124,16 @@ pipeline {
                         steps {
                             echo "Build ${NODE}"
                             script {
-                                if (isUnix()) {
-                                    sh """. ${ENV_LOC[NODE]}/bin/activate
-                                          invoke build-samples
-                                    """
-                                } else {
-                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                          invoke build-samples
-                                    """
+                                configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+                                    if (isUnix()) {
+                                        sh """. ${ENV_LOC[NODE]}/bin/activate
+                                              invoke build-samples
+                                        """
+                                    } else {
+                                        bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                              invoke build-samples
+                                        """
+                                    }
                                 }
                             }
                         }
@@ -152,14 +158,16 @@ pipeline {
                         steps {
                             echo "Clean ${NODE}"
                             script {
-                                if (isUnix()) {
-                                    sh """. ${ENV_LOC[NODE]}/bin/activate
-                                          invoke clean-samples
-                                    """
-                                } else {
-                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                          invoke clean-samples
-                                    """
+                                configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+                                    if (isUnix()) {
+                                        sh """. ${ENV_LOC[NODE]}/bin/activate
+                                              invoke clean-samples
+                                        """
+                                    } else {
+                                        bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                              invoke clean-samples
+                                        """
+                                    }
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 def ENV_LOC=[:]
 pipeline {
     parameters {
-        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples'], description: 'Run on specific platform')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-samples', 'windows-arm-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples', 'rocky9-arm-java-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
     }
@@ -29,7 +29,7 @@ pipeline {
                 axes {
                     axis {
                         name 'NODE'
-                        values 'windows-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples'
+                        values 'windows-java-samples', 'windows-arm-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples', 'rocky9-arm-java-samples'
                     }
                 }
                 environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                     CONAN_USER_HOME = "${WORKSPACE}"
                     CONAN_NON_INTERACTIVE = '1'
                     CONAN_PRINT_RUN_COMMANDS = '1'
+                    APDFL_KEY = credentials('apdfl-rlm-key')
                 }
                 stages {
                     stage('Axis'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,15 +185,23 @@ def patchMavenSettings() {
     if (!env.CONAN_LOGIN_USERNAME) {
         error '[ERROR] CONAN_LOGIN_USERNAME is not set'
     }
-    def originalSettings = readFile(env.MAVEN_SETTINGS)
-    def patchedSettings = originalSettings
-        .replace('${CONAN_LOGIN_USERNAME}', env.CONAN_LOGIN_USERNAME)
-        .replace('${CONAN_PASSWORD}', env.CONAN_PASSWORD)
-        .replace('<username></username>', "<username>${env.CONAN_LOGIN_USERNAME}</username>")
-        .replace('<username/>', "<username>${env.CONAN_LOGIN_USERNAME}</username>")
-        .replace('<password></password>', "<password>${env.CONAN_PASSWORD}</password>")
-        .replace('<password/>', "<password>${env.CONAN_PASSWORD}</password>")
-    if (patchedSettings != originalSettings) {
-        writeFile file: env.MAVEN_SETTINGS, text: patchedSettings
+    def original = readFile(env.MAVEN_SETTINGS)
+    def start = original.indexOf('<servers>')
+    def end = original.indexOf('</servers>')
+    if (start < 0 || end < 0) {
+        error '[ERROR] No <servers> block found in the Maven settings'
     }
+    def serversBlock = """<servers>
+    <server>
+      <username>${env.CONAN_LOGIN_USERNAME}</username>
+      <password>${env.CONAN_PASSWORD}</password>
+      <id>central</id>
+    </server>
+    <server>
+      <username>${env.CONAN_LOGIN_USERNAME}</username>
+      <password>${env.CONAN_PASSWORD}</password>
+      <id>snapshots</id>
+    </server>
+  """
+    writeFile file: env.MAVEN_SETTINGS, text: original.substring(0, start) + serversBlock + original.substring(end)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                     CONAN_USER_HOME = "${WORKSPACE}"
                     CONAN_NON_INTERACTIVE = '1'
                     CONAN_PRINT_RUN_COMMANDS = '1'
+                    CONAN_LOGIN_USERNAME = 'devauto'
                 }
                 stages {
                     stage('Axis'){
@@ -106,16 +107,14 @@ pipeline {
                         steps {
                             echo "Clean ${NODE}"
                             script {
-                                configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-                                    if (isUnix()) {
-                                        sh """. ${ENV_LOC[NODE]}/bin/activate
-                                              invoke clean-samples
-                                        """
-                                    } else {
-                                        bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                              invoke clean-samples
-                                        """
-                                    }
+                                if (isUnix()) {
+                                    sh """. ${ENV_LOC[NODE]}/bin/activate
+                                          invoke clean-samples
+                                    """
+                                } else {
+                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                          invoke clean-samples
+                                    """
                                 }
                             }
                         }
@@ -124,15 +123,18 @@ pipeline {
                         steps {
                             echo "Build ${NODE}"
                             script {
-                                configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-                                    if (isUnix()) {
-                                        sh """. ${ENV_LOC[NODE]}/bin/activate
-                                              invoke build-samples
-                                        """
-                                    } else {
-                                        bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                              invoke build-samples
-                                        """
+                                withCredentials([string(credentialsId: 'jfrog-dev-token', variable: 'CONAN_PASSWORD')]) {
+                                    configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
+                                        patchMavenSettings()
+                                        if (isUnix()) {
+                                            sh """. ${ENV_LOC[NODE]}/bin/activate
+                                                  invoke build-samples
+                                            """
+                                        } else {
+                                            bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                                  invoke build-samples
+                                            """
+                                        }
                                     }
                                 }
                             }
@@ -158,16 +160,14 @@ pipeline {
                         steps {
                             echo "Clean ${NODE}"
                             script {
-                                configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-                                    if (isUnix()) {
-                                        sh """. ${ENV_LOC[NODE]}/bin/activate
-                                              invoke clean-samples
-                                        """
-                                    } else {
-                                        bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                              invoke clean-samples
-                                        """
-                                    }
+                                if (isUnix()) {
+                                    sh """. ${ENV_LOC[NODE]}/bin/activate
+                                          invoke clean-samples
+                                    """
+                                } else {
+                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                          invoke clean-samples
+                                    """
                                 }
                             }
                         }
@@ -175,5 +175,25 @@ pipeline {
                 }
             }
         }
+    }
+}
+
+def patchMavenSettings() {
+    if (!env.CONAN_PASSWORD) {
+        error '[ERROR] CONAN_PASSWORD is not set (missing Jenkins credentials binding)'
+    }
+    if (!env.CONAN_LOGIN_USERNAME) {
+        error '[ERROR] CONAN_LOGIN_USERNAME is not set'
+    }
+    def originalSettings = readFile(env.MAVEN_SETTINGS)
+    def patchedSettings = originalSettings
+        .replace('${CONAN_LOGIN_USERNAME}', env.CONAN_LOGIN_USERNAME)
+        .replace('${CONAN_PASSWORD}', env.CONAN_PASSWORD)
+        .replace('<username></username>', "<username>${env.CONAN_LOGIN_USERNAME}</username>")
+        .replace('<username/>', "<username>${env.CONAN_LOGIN_USERNAME}</username>")
+        .replace('<password></password>', "<password>${env.CONAN_PASSWORD}</password>")
+        .replace('<password/>', "<password>${env.CONAN_PASSWORD}</password>")
+    if (patchedSettings != originalSettings) {
+        writeFile file: env.MAVEN_SETTINGS, text: patchedSettings
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,6 @@ pipeline {
                     CONAN_USER_HOME = "${WORKSPACE}"
                     CONAN_NON_INTERACTIVE = '1'
                     CONAN_PRINT_RUN_COMMANDS = '1'
-                    CONAN_LOGIN_USERNAME = 'devauto'
                 }
                 stages {
                     stage('Axis'){
@@ -123,19 +122,14 @@ pipeline {
                         steps {
                             echo "Build ${NODE}"
                             script {
-                                withCredentials([string(credentialsId: 'jfrog-dev-token', variable: 'CONAN_PASSWORD')]) {
-                                    configFileProvider([configFile(fileId: 'devauto-maven-settings', variable: 'MAVEN_SETTINGS')]) {
-                                        patchMavenSettings()
-                                        if (isUnix()) {
-                                            sh """. ${ENV_LOC[NODE]}/bin/activate
-                                                  invoke build-samples
-                                            """
-                                        } else {
-                                            bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
-                                                  invoke build-samples
-                                            """
-                                        }
-                                    }
+                                if (isUnix()) {
+                                    sh """. ${ENV_LOC[NODE]}/bin/activate
+                                          invoke build-samples
+                                    """
+                                } else {
+                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                          invoke build-samples
+                                    """
                                 }
                             }
                         }
@@ -176,32 +170,4 @@ pipeline {
             }
         }
     }
-}
-
-def patchMavenSettings() {
-    if (!env.CONAN_PASSWORD) {
-        error '[ERROR] CONAN_PASSWORD is not set (missing Jenkins credentials binding)'
-    }
-    if (!env.CONAN_LOGIN_USERNAME) {
-        error '[ERROR] CONAN_LOGIN_USERNAME is not set'
-    }
-    def original = readFile(env.MAVEN_SETTINGS)
-    def start = original.indexOf('<servers>')
-    def end = original.indexOf('</servers>')
-    if (start < 0 || end < 0) {
-        error '[ERROR] No <servers> block found in the Maven settings'
-    }
-    def serversBlock = """<servers>
-    <server>
-      <username>${env.CONAN_LOGIN_USERNAME}</username>
-      <password>${env.CONAN_PASSWORD}</password>
-      <id>central</id>
-    </server>
-    <server>
-      <username>${env.CONAN_LOGIN_USERNAME}</username>
-      <password>${env.CONAN_PASSWORD}</password>
-      <id>snapshots</id>
-    </server>
-  """
-    writeFile file: env.MAVEN_SETTINGS, text: original.substring(0, start) + serversBlock + original.substring(end)
 }

--- a/OpticalCharacterRecognition/AddTextToDocument/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToDocument/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/OpticalCharacterRecognition/AddTextToImage/pom.xml
+++ b/OpticalCharacterRecognition/AddTextToImage/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/OpticalCharacterRecognition/OCRDocument/pom.xml
+++ b/OpticalCharacterRecognition/OCRDocument/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Other/MemoryFileSystem/pom.xml
+++ b/Other/MemoryFileSystem/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Other/StreamIO/pom.xml
+++ b/Other/StreamIO/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Printing/PrintPDF/pom.xml
+++ b/Printing/PrintPDF/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Printing/PrintPDFGUI/pom.xml
+++ b/Printing/PrintPDFGUI/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ a valid activation key <b>prior</b> to instantiating the library.
 ```
 
 ## Running the Samples
-**For x64 Windows, x64 Linux, or macOS ARM systems:**
+**For x64 Windows, Windows ARM64, x64 Linux, Linux ARM64, or macOS ARM systems:**
 Samples can be built and run easily in the [IntelliJ IDEA](https://www.jetbrains.com/idea/) IDE.
 
 1. Clone this repository

--- a/Security/AddBasicPAdESElectronicSignature/pom.xml
+++ b/Security/AddBasicPAdESElectronicSignature/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Security/AddDigitalSignatureCMS/pom.xml
+++ b/Security/AddDigitalSignatureCMS/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Security/AddDigitalSignatureRFC3161/pom.xml
+++ b/Security/AddDigitalSignatureRFC3161/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Security/AddPAdESPolicySignature/pom.xml
+++ b/Security/AddPAdESPolicySignature/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Security/AddRegexRedaction/pom.xml
+++ b/Security/AddRegexRedaction/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Security/Redactions/pom.xml
+++ b/Security/Redactions/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/AddGlyphs/pom.xml
+++ b/Text/AddGlyphs/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/AddUnicodeText/pom.xml
+++ b/Text/AddUnicodeText/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/AddVerticalText/pom.xml
+++ b/Text/AddVerticalText/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/ListWords/pom.xml
+++ b/Text/ListWords/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/RegexExtractText/pom.xml
+++ b/Text/RegexExtractText/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/RegexTextSearch/pom.xml
+++ b/Text/RegexTextSearch/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/Text/TextExtract/pom.xml
+++ b/Text/TextExtract/pom.xml
@@ -46,6 +46,31 @@
         <jni.classifier>linux-x86-64-jni</jni.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>WindowsArm64</id>
+      <activation>
+        <os>
+          <family>windows</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>win-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>LinuxArm64</id>
+      <activation>
+        <os>
+          <!-- Use OS <name> instead of <family> because the "unix" <family> also includes Mac -->
+          <name>Linux</name>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <jni.classifier>linux-arm-64-jni</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>

--- a/tasks.py
+++ b/tasks.py
@@ -93,28 +93,13 @@ samples_list = [
         ]
 
 
-def mvn_command(goal):
-    """Build an 'mvn <goal>' command line.
-
-    If the MAVEN_SETTINGS environment variable is set (e.g. by the Jenkins
-    Config File Provider, which exposes the managed devauto-maven-settings
-    file), pass it with -s so Maven resolves the APDFL artifacts from the
-    DL Artifactory mirror instead of public Maven Central. When it is not
-    set (e.g. a developer machine), fall back to the default
-    ~/.m2/settings.xml."""
-    settings = os.environ.get('MAVEN_SETTINGS')
-    if settings:
-        return f'mvn -s "{settings}" {goal}'
-    return f'mvn {goal}'
-
-
 @task()
 def clean_samples(ctx):
     """Cleans files that were generated from building the samples"""
     for sample in samples_list:
         full_path = os.path.join(os.getcwd(), sample)
         with ctx.cd(full_path):
-            ctx.run(mvn_command('clean'))
+            ctx.run('mvn clean')
             ctx.run('git clean -fdx')
 
 
@@ -139,7 +124,7 @@ def build_samples(ctx):
             continue
 
         with ctx.cd(full_path):
-            ctx.run(mvn_command('package'))
+            ctx.run('mvn package')
 
 
 def remove_last_path_entry():

--- a/tasks.py
+++ b/tasks.py
@@ -93,13 +93,28 @@ samples_list = [
         ]
 
 
+def mvn_command(goal):
+    """Build an 'mvn <goal>' command line.
+
+    If the MAVEN_SETTINGS environment variable is set (e.g. by the Jenkins
+    Config File Provider, which exposes the managed devauto-maven-settings
+    file), pass it with -s so Maven resolves the APDFL artifacts from the
+    DL Artifactory mirror instead of public Maven Central. When it is not
+    set (e.g. a developer machine), fall back to the default
+    ~/.m2/settings.xml."""
+    settings = os.environ.get('MAVEN_SETTINGS')
+    if settings:
+        return f'mvn -s "{settings}" {goal}'
+    return f'mvn {goal}'
+
+
 @task()
 def clean_samples(ctx):
     """Cleans files that were generated from building the samples"""
     for sample in samples_list:
         full_path = os.path.join(os.getcwd(), sample)
         with ctx.cd(full_path):
-            ctx.run('mvn clean')
+            ctx.run(mvn_command('clean'))
             ctx.run('git clean -fdx')
 
 
@@ -124,7 +139,7 @@ def build_samples(ctx):
             continue
 
         with ctx.cd(full_path):
-            ctx.run('mvn package')
+            ctx.run(mvn_command('package'))
 
 
 def remove_last_path_entry():

--- a/tasks.py
+++ b/tasks.py
@@ -94,13 +94,13 @@ samples_list = [
 
 
 def skip_on_windows_arm(sample):
-    # Forms Extension is not available for Windows ARM on APDFL 21, so its
-    # samples cannot be built or run there.
-    forms_samples = ('ConvertXFAToAcroForms', 'ExportFormsData',
-                     'FlattenForms', 'ImportFormsData')
+    # These samples use APDFL features that are not implemented on Windows ARM
+    # for APDFL 21 (Forms Extension and Office conversion).
+    unsupported = ('ConvertXFAToAcroForms', 'ExportFormsData', 'FlattenForms',
+                   'ImportFormsData', 'ConvertToOffice')
     is_windows_arm = (platform.system() == 'Windows' and
                       platform.machine().lower() in ('arm64', 'aarch64'))
-    return is_windows_arm and any(s in sample for s in forms_samples)
+    return is_windows_arm and any(s in sample for s in unsupported)
 
 
 @task()
@@ -120,7 +120,7 @@ def build_samples(ctx):
         full_path = os.path.join(os.getcwd(), sample)
 
         if skip_on_windows_arm(sample):
-            print(f'{sample} Forms Extension not available on Windows ARM')
+            print(f'{sample} not available on Windows ARM')
             continue
 
         if platform.system() == 'Darwin' and ('ConvertToOffice' in sample or
@@ -187,7 +187,7 @@ def run_samples(ctx):
 
     for sample in samples_list:
         if skip_on_windows_arm(sample):
-            print(f'{sample} Forms Extension not available on Windows ARM')
+            print(f'{sample} not available on Windows ARM')
             continue
 
         if platform.system() == "Windows":

--- a/tasks.py
+++ b/tasks.py
@@ -93,6 +93,16 @@ samples_list = [
         ]
 
 
+def skip_on_windows_arm(sample):
+    # Forms Extension is not available for Windows ARM on APDFL 21, so its
+    # samples cannot be built or run there.
+    forms_samples = ('ConvertXFAToAcroForms', 'ExportFormsData',
+                     'FlattenForms', 'ImportFormsData')
+    is_windows_arm = (platform.system() == 'Windows' and
+                      platform.machine().lower() in ('arm64', 'aarch64'))
+    return is_windows_arm and any(s in sample for s in forms_samples)
+
+
 @task()
 def clean_samples(ctx):
     """Cleans files that were generated from building the samples"""
@@ -108,6 +118,10 @@ def build_samples(ctx):
     """Builds the APDFL Java Maven samples"""
     for sample in samples_list:
         full_path = os.path.join(os.getcwd(), sample)
+
+        if skip_on_windows_arm(sample):
+            print(f'{sample} Forms Extension not available on Windows ARM')
+            continue
 
         if platform.system() == 'Darwin' and ('ConvertToOffice' in sample or
                                               'CreateDocFromXPS' in sample or
@@ -172,6 +186,10 @@ def run_samples(ctx):
         raise ValueError("APDFL_KEY environment variable not set.")
 
     for sample in samples_list:
+        if skip_on_windows_arm(sample):
+            print(f'{sample} Forms Extension not available on Windows ARM')
+            continue
+
         if platform.system() == "Windows":
             os.environ["PATH"] += ";"
 

--- a/using_on_other_platforms.md
+++ b/using_on_other_platforms.md
@@ -2,9 +2,9 @@
 
 ## Installing APDFL for non license managed platforms
 
-[Maven Central](https://central.sonatype.com/artifact/com.datalogics.pdfl/pdfl) offers self-activating license managed APDFL packages for 64-bit Windows, 64-bit Intel Linux, and Mac systems running Mac ARM. The samples in this repo will automatically download the APDFL package for your platform via Maven and obtain a trial license.
+[Maven Central](https://central.sonatype.com/artifact/com.datalogics.pdfl/pdfl) offers self-activating license managed APDFL packages for 64-bit Windows, 64-bit Windows ARM, 64-bit Intel Linux, 64-bit Linux ARM, and Mac systems running Mac ARM. The samples in this repo will automatically download the APDFL package for your platform via Maven and obtain a trial license.
 
-Customers can also obtain APDFL without license management for the same three platforms, plus those listed below. You will receive a ZIP file with the APDFL components for your platform, plus a POM file (`create-artifacts.xml`) that you can use to install APDFL to your local Maven cache, or deploy to private Maven repo on your network. To install the components to your local cache, unzip the file and run the command
+Customers can also obtain APDFL without license management for the same five platforms, plus those listed below. You will receive a ZIP file with the APDFL components for your platform, plus a POM file (`create-artifacts.xml`) that you can use to install APDFL to your local Maven cache, or deploy to private Maven repo on your network. To install the components to your local cache, unzip the file and run the command
 
 ```
 ./mvnw -f create-artifacts.xml install
@@ -30,22 +30,6 @@ After you've installed APDFL for your platform to your Maven cache, you can run 
       </activation>
       <properties>
         <jni.classifier>mac-x86-64-jni</jni.classifier>
-      </properties>
-    </profile>
-```
-
-### **Linux ARM (64-bit)**
-```
-    <profile>
-      <id>LinuxArm</id>
-      <activation>
-        <os>
-          <name>Linux</name>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-      <properties>
-        <jni.classifier>linux-arm-64-jni</jni.classifier>
       </properties>
     </profile>
 ```
@@ -94,21 +78,6 @@ After you've installed APDFL for your platform to your Maven cache, you can run 
       </activation>
       <properties>
         <jni.classifier>linux-x86-32-jni</jni.classifier>
-      </properties>
-    </profile>
-```
-### **Windows ARM (64-bit)**
-```
-    <profile>
-      <id>WindowsArm</id>
-      <activation>
-        <os>
-          <family>windows</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-      <properties>
-        <jni.classifier>win-arm-64-jni</jni.classifier>
       </properties>
     </profile>
 ```


### PR DESCRIPTION
Adds Windows ARM64 and Linux ARM as supported platforms for the Java samples (APDFL-6776).

## Changes in this pull request
- **Poms (91):** add `WindowsArm64` (`win-arm-64-jni`) and `LinuxArm64` (`linux-arm-64-jni`) Maven profiles to every sample, paired with the existing `Windows64` / `Linux64` profiles. Activated by os family/name + `arch=aarch64`; the existing `<dependency>` blocks already reference `${jni.classifier}`, so no dependency edits were needed.
- **Jenkinsfile:** add `windows-arm-java-samples` and `rocky9-arm-java-samples` to the matrix axis and `PLATFORM_FILTER` so CI exercises both new platforms; inject the RLM key via `APDFL_KEY = credentials('apdfl-rlm-key')` in the matrix environment so the Run Samples stage can run.
- **tasks.py:** skip samples on Windows ARM that use APDFL features with no Windows ARM implementation in APDFL 21 — the Forms samples (`ConvertXFAToAcroForms`, `ExportFormsData`, `FlattenForms`, `ImportFormsData`; no `forms-extension` `win-arm-64-jni` native) and `ConvertToOffice` (`PLATFORM_HAS_PDFTOOFFICE` is undefined for Windows ARM).
- **Docs:** remove the now-obsolete Linux ARM / Windows ARM sections from `using_on_other_platforms.md` (built into the poms now), add the two platforms to its intro lists, and add them to the `README` supported-platform list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
