### PR TITLE
Use the credential store for the APDFL license key.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                     CONAN_USER_HOME = "${WORKSPACE}"
                     CONAN_NON_INTERACTIVE = '1'
                     CONAN_PRINT_RUN_COMMANDS = '1'
+                    APDFL_KEY = credentials('apdfl-rlm-key')
                 }
                 stages {
                     stage('Axis'){


### PR DESCRIPTION
Use the credential store for the APDFK license key
We should have been doing this all along, but better late than never.
It will allow us to eliminate this setting from node configurations in tycho