### PR TITLE
Use a job-local Maven cache in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ $RECYCLE.BIN/
 /*_debug_lm
 /icons
 activate*
+# Jenkins job-local Maven repository
+/.m2repo

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ def ENV_LOC=[:]
 pipeline {
     parameters {
         choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-samples', 'windows-arm-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples', 'rocky9-arm-java-samples'], description: 'Run on specific platform')
-        booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
+        booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Maven package cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
     }
     options{
@@ -33,10 +33,10 @@ pipeline {
                     }
                 }
                 environment {
-                    CONAN_USER_HOME = "${WORKSPACE}"
-                    CONAN_NON_INTERACTIVE = '1'
-                    CONAN_PRINT_RUN_COMMANDS = '1'
                     APDFL_KEY = credentials('apdfl-rlm-key')
+                    // Job-local Maven repository; the node-wide ~/.m2 is shared with
+                    // deploy jobs that install unreleased artifacts into it.
+                    MAVEN_OPTS = "-Dmaven.repo.local=${WORKSPACE}/.m2repo"
                 }
                 stages {
                     stage('Axis'){
@@ -52,24 +52,24 @@ pipeline {
                         }
                         steps {
                             echo "Clean ${NODE}"
+                            // Removes the package caches only on manually-triggered builds
+                            cleanPackageCaches()
                             script {
                                 // Ensure that the checkout is clean and any changes
                                 // to .gitattributes and .gitignore have been taken
-                                // into effect
+                                // into effect. The Maven package cache is excluded:
+                                // cleanPackageCaches owns its removal.
                                 if (isUnix()) {
                                     sh """
                                           git rm -f -q -r .
                                           git reset --hard HEAD
-                                          git clean -fdx
+                                          git clean -fdx -e .m2repo
                                     """
                                 } else {
-                                    // On Windows, 'git clean' can't handle long paths in .conan,
-                                    // so remove that first.
                                     bat """
-                                          if exist ${WORKSPACE}\\.conan\\ rmdir/s/q ${WORKSPACE}\\.conan
                                           git rm -q -r .
                                           git reset --hard HEAD
-                                          git clean -fdx
+                                          git clean -fdx -e .m2repo
                                     """
                                 }
                             }


### PR DESCRIPTION
## Summary

Points Maven at a workspace-local repository (`.m2repo`) via `MAVEN_OPTS`, isolating this job from the node-wide `~/.m2`.

## Motivation

The nightly `develop-21` samples builds have failed since July 11. The build nodes are shared with the maven-builder deploy jobs, whose `mvn deploy -DrepositoryId=central` installs unreleased artifacts (currently `pdfl 21.1.0`) into the node-wide `~/.m2` and poisons the cached `central` metadata. The open version range `[21.0,22.0)` in the sample POMs then selects 21.1.0, which neither Maven Central (latest: 21.0.1) nor any repository configured on the samples nodes can serve, failing with `Could not find artifact com.datalogics.pdfl:pdfl:zip:resources:21.1.0`.

With an isolated cache the job resolves against its actual remotes and builds the latest public release. Note this means the nightlies test the released 21.0.1, not the internal 21.1.0, until that ships publicly.

## Changes

- `MAVEN_OPTS = "-Dmaven.repo.local=${WORKSPACE}/.m2repo"` in the matrix environment; applies to every `mvn` invocation.
- The cache persists between nightly runs. `CLEAN_WORKSPACE` builds call the new `cleanPackageCaches` shared-library step (datalogics/jenkins-shared-libraries#86), which removes it only on manually-triggered builds; `git clean` now excludes it.
- `.m2repo` added to `.gitignore`.
- Removed the Conan environment settings and the Windows `.conan` cleanup — this Maven-only job never used Conan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)