### PR TITLE
Remove nightly build trigger for develop-18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,6 @@ pipeline {
         timeout(time: 4, unit: "HOURS")
     }
     agent none
-    triggers {
-        // The job will be triggered only for the develop branch at 7am every day.
-        parameterizedCron(env.BRANCH_NAME == "develop-18" ? "0 7 * * *" : "")
-    }
     stages {
         stage('Matrix stage') {
             matrix {


### PR DESCRIPTION
Removes the `triggers` block so the develop-18 branch no longer builds nightly.

Now that we have APDFL 21 available, we want to merge this and make develop-21 the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)