### PR TITLE
Use java-21 node labels on develop-21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 def ENV_LOC=[:]
 pipeline {
     parameters {
-        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-samples', 'windows-arm-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples', 'rocky9-arm-java-samples'], description: 'Run on specific platform')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-java-21-samples', 'windows-arm-java-21-samples', 'mac-arm-java-21-samples', 'rocky9-java-21-samples', 'rocky9-arm-java-21-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Maven package cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
     }
@@ -29,7 +29,7 @@ pipeline {
                 axes {
                     axis {
                         name 'NODE'
-                        values 'windows-java-samples', 'windows-arm-java-samples', 'mac-arm-java-samples', 'rocky9-java-samples', 'rocky9-arm-java-samples'
+                        values 'windows-java-21-samples', 'windows-arm-java-21-samples', 'mac-arm-java-21-samples', 'rocky9-java-21-samples', 'rocky9-arm-java-21-samples'
                     }
                 }
                 environment {


### PR DESCRIPTION
Switches the PLATFORM_FILTER choices and matrix axis values to the new node labels created for the APDFL 21 samples: `windows-java-21-samples`, `windows-arm-java-21-samples`, `mac-arm-java-21-samples`, `rocky9-java-21-samples`, and `rocky9-arm-java-21-samples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)